### PR TITLE
Fix permission check: use repo write access instead of org membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ jobs:
           action: create_task
           coder-url: ${{ secrets.CODER_URL }}
           coder-token: ${{ secrets.CODER_TOKEN }}
-          github-token: ${{ github.token }}
           prompt: |
             You are an autonomous AI agent. Resolve the GitHub issue below.
             Read the issue, develop a plan, post it as a comment, then implement and open a PR.
@@ -65,7 +64,6 @@ jobs:
           action: close_task
           coder-url: ${{ secrets.CODER_URL }}
           coder-token: ${{ secrets.CODER_TOKEN }}
-          github-token: ${{ github.token }}
 
   pr-comment:
     runs-on: ubuntu-latest
@@ -82,7 +80,6 @@ jobs:
           action: pr_comment
           coder-url: ${{ secrets.CODER_URL }}
           coder-token: ${{ secrets.CODER_TOKEN }}
-          github-token: ${{ github.token }}
 
   issue-comment:
     runs-on: ubuntu-latest
@@ -98,7 +95,6 @@ jobs:
           action: issue_comment
           coder-url: ${{ secrets.CODER_URL }}
           coder-token: ${{ secrets.CODER_TOKEN }}
-          github-token: ${{ github.token }}
 ```
 
 ### `.github/workflows/coder-failed-checks.yml`
@@ -130,7 +126,6 @@ jobs:
           action: failed_check
           coder-url: ${{ secrets.CODER_URL }}
           coder-token: ${{ secrets.CODER_TOKEN }}
-          github-token: ${{ github.token }}
 ```
 
 ## Inputs
@@ -141,13 +136,12 @@ jobs:
 | `coder-url` | Yes | — | Coder deployment URL |
 | `coder-token` | Yes | — | Coder API session token |
 | `coder-username` | No | `xmtp-coder-agent` | Coder username that owns tasks |
-| `github-token` | Yes | — | GitHub token for API operations |
+| `github-token` | No | `GITHUB_TOKEN` | GitHub token for API operations (auto-detected from environment) |
 | `coder-task-name-prefix` | No | `gh` | Prefix for deterministic task names |
 | `coder-template-name` | No | `task-template` | Coder template for workspace creation (`create_task` only) |
 | `coder-template-preset` | No | — | Template preset to use (`create_task` only) |
 | `coder-organization` | No | `default` | Coder organization (`create_task` only) |
 | `prompt` | No | — | Custom prompt text — issue URL is always appended (`create_task` only) |
-| `github-org` | No | `xmtp` | GitHub org for membership validation (`create_task` only) |
 | `coder-github-username` | No | `xmtp-coder-agent` | GitHub username of the designated coder agent |
 
 ## Outputs
@@ -158,7 +152,7 @@ jobs:
 | `task-url` | URL to view the task in Coder |
 | `task-status` | Task status after the action completes |
 | `skipped` | `"true"` if the action was skipped |
-| `skip-reason` | Why the action was skipped (e.g., `non-org-member`, `self-comment`, `task-not-found`) |
+| `skip-reason` | Why the action was skipped (e.g., `insufficient-permissions`, `self-comment`, `task-not-found`) |
 
 ## Required Secrets
 
@@ -175,9 +169,9 @@ The `github-token` input uses the default `${{ github.token }}` provided by GitH
 
 Tasks use deterministic names: `{prefix}-{repo}-{issue_number}` (e.g., `gh-libxmtp-42`). This allows any mode to locate the correct task from just the repo name and issue number, without querying the Coder API first.
 
-### Org Membership Validation
+### Permission Validation
 
-When `create_task` runs, it verifies the actor (the person who assigned the issue) is a member of the configured GitHub org. Non-members are rejected with a clear log message. This prevents unauthorized users from spawning Coder tasks.
+When `create_task` runs, it verifies the actor (the person who assigned the issue) has write access to the repository. Users without write access are rejected with a clear log message. This prevents unauthorized users from spawning Coder tasks.
 
 ### Comment Forwarding
 

--- a/action.yml
+++ b/action.yml
@@ -39,12 +39,8 @@ inputs:
     description: "Custom prompt text — issue URL is always appended (create_task only)"
     required: false
   github-token:
-    description: "GitHub token for API operations"
-    required: true
-  github-org:
-    description: "GitHub org for membership validation (create_task only)"
+    description: "GitHub token for API operations. Defaults to the workflow's GITHUB_TOKEN."
     required: false
-    default: "xmtp"
   coder-github-username:
     description: "GitHub username of the designated coder agent"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -26233,20 +26233,19 @@ class GitHubClient {
   constructor(octokit) {
     this.octokit = octokit;
   }
-  async checkOrgMembership(org, username) {
+  async checkActorPermission(owner, repo, username) {
     try {
-      await this.octokit.rest.orgs.checkMembershipForUser({
-        org,
+      const { data } = await this.octokit.rest.repos.getCollaboratorPermissionLevel({
+        owner,
+        repo,
         username
       });
-      return true;
+      const allowed = new Set(["admin", "write"]);
+      return allowed.has(data.permission);
     } catch (error2) {
       const err = error2;
       if (err?.status === 404)
         return false;
-      if (err?.status === 403) {
-        throw new Error(`Insufficient permissions to check org membership for ${org}. ` + `Ensure the github-token has read:org scope.`);
-      }
       throw error2;
     }
   }
@@ -26350,7 +26349,6 @@ var BaseInputsSchema = exports_external.object({
   coderUsername: exports_external.string().min(1).default("xmtp-coder-agent"),
   coderTaskNamePrefix: exports_external.string().min(1).default("gh"),
   githubToken: exports_external.string().min(1),
-  githubOrg: exports_external.string().min(1).default("xmtp"),
   coderGithubUsername: exports_external.string().min(1).default("xmtp-coder-agent")
 });
 var CreateTaskInputsSchema = BaseInputsSchema.extend({
@@ -26427,10 +26425,10 @@ class CreateTaskHandler {
     this.context = context3;
   }
   async run() {
-    const isMember = await this.github.checkOrgMembership(this.inputs.githubOrg, this.context.senderLogin);
-    if (!isMember) {
-      error(`Actor ${this.context.senderLogin} is not a member of ${this.inputs.githubOrg}, skipping task creation`);
-      return { skipped: true, skipReason: "non-org-member" };
+    const hasAccess = await this.github.checkActorPermission(this.context.owner, this.context.repo, this.context.senderLogin);
+    if (!hasAccess) {
+      error(`Actor ${this.context.senderLogin} does not have write access to ${this.context.owner}/${this.context.repo}, skipping task creation`);
+      return { skipped: true, skipReason: "insufficient-permissions" };
     }
     const taskName = generateTaskName(this.inputs.coderTaskNamePrefix, this.context.repo, this.context.issueNumber);
     info(`Task name: ${taskName}`);
@@ -26745,8 +26743,7 @@ async function run() {
       coderTemplatePreset: getInput("coder-template-preset") || undefined,
       coderOrganization: getInput("coder-organization") || undefined,
       prompt: getInput("prompt") || undefined,
-      githubToken: getInput("github-token", { required: true }),
-      githubOrg: getInput("github-org") || undefined,
+      githubToken: getInput("github-token") || process.env.GITHUB_TOKEN || "",
       coderGithubUsername: getInput("coder-github-username") || undefined
     };
     setSecret(rawInputs.coderToken);

--- a/src/github-client.test.ts
+++ b/src/github-client.test.ts
@@ -4,9 +4,11 @@ import { GitHubClient } from "./github-client";
 function createMockOctokit(overrides: Record<string, unknown> = {}) {
 	return {
 		rest: {
-			orgs: {
-				checkMembershipForUser: mock(() => Promise.resolve({ status: 204 })),
-				...(overrides.orgs as Record<string, unknown>),
+			repos: {
+				getCollaboratorPermissionLevel: mock(() =>
+					Promise.resolve({ data: { permission: "write" } }),
+				),
+				...(overrides.repos as Record<string, unknown>),
 			},
 			issues: {
 				listComments: mock(() => Promise.resolve({ data: [] })),
@@ -42,35 +44,59 @@ function createMockOctokit(overrides: Record<string, unknown> = {}) {
 }
 
 describe("GitHubClient", () => {
-	describe("checkOrgMembership", () => {
-		test("returns true for org members", async () => {
+	describe("checkActorPermission", () => {
+		test("returns true for users with write access", async () => {
 			const octokit = createMockOctokit();
 			const client = new GitHubClient(octokit);
-			const result = await client.checkOrgMembership("xmtp", "member-user");
+			const result = await client.checkActorPermission("org", "repo", "writer");
 			expect(result).toBe(true);
 		});
 
-		test("returns false for non-members (404)", async () => {
+		test("returns true for admins", async () => {
 			const octokit = createMockOctokit({
-				orgs: {
-					checkMembershipForUser: mock(() => Promise.reject({ status: 404 })),
+				repos: {
+					getCollaboratorPermissionLevel: mock(() =>
+						Promise.resolve({ data: { permission: "admin" } }),
+					),
 				},
 			});
 			const client = new GitHubClient(octokit);
-			const result = await client.checkOrgMembership("xmtp", "outsider");
+			const result = await client.checkActorPermission(
+				"org",
+				"repo",
+				"admin-user",
+			);
+			expect(result).toBe(true);
+		});
+
+		test("returns false for read-only users", async () => {
+			const octokit = createMockOctokit({
+				repos: {
+					getCollaboratorPermissionLevel: mock(() =>
+						Promise.resolve({ data: { permission: "read" } }),
+					),
+				},
+			});
+			const client = new GitHubClient(octokit);
+			const result = await client.checkActorPermission("org", "repo", "reader");
 			expect(result).toBe(false);
 		});
 
-		test("throws on 403 (insufficient token permissions)", async () => {
+		test("returns false when user not found (404)", async () => {
 			const octokit = createMockOctokit({
-				orgs: {
-					checkMembershipForUser: mock(() => Promise.reject({ status: 403 })),
+				repos: {
+					getCollaboratorPermissionLevel: mock(() =>
+						Promise.reject({ status: 404 }),
+					),
 				},
 			});
 			const client = new GitHubClient(octokit);
-			expect(client.checkOrgMembership("xmtp", "user")).rejects.toThrow(
-				/insufficient permissions/i,
+			const result = await client.checkActorPermission(
+				"org",
+				"repo",
+				"outsider",
 			);
+			expect(result).toBe(false);
 		});
 	});
 

--- a/src/github-client.ts
+++ b/src/github-client.ts
@@ -24,22 +24,23 @@ export interface PRInfo {
 export class GitHubClient {
 	constructor(private readonly octokit: Octokit) {}
 
-	async checkOrgMembership(org: string, username: string): Promise<boolean> {
+	async checkActorPermission(
+		owner: string,
+		repo: string,
+		username: string,
+	): Promise<boolean> {
 		try {
-			await this.octokit.rest.orgs.checkMembershipForUser({
-				org,
-				username,
-			});
-			return true;
+			const { data } =
+				await this.octokit.rest.repos.getCollaboratorPermissionLevel({
+					owner,
+					repo,
+					username,
+				});
+			const allowed = new Set(["admin", "write"]);
+			return allowed.has(data.permission);
 		} catch (error: unknown) {
 			const err = error as { status?: number };
 			if (err?.status === 404) return false;
-			if (err?.status === 403) {
-				throw new Error(
-					`Insufficient permissions to check org membership for ${org}. ` +
-						`Ensure the github-token has read:org scope.`,
-				);
-			}
 			throw error;
 		}
 	}

--- a/src/handlers/close-task.test.ts
+++ b/src/handlers/close-task.test.ts
@@ -16,7 +16,6 @@ const baseInputs: CloseTaskInputs = {
 	coderUsername: "coder-agent",
 	coderTaskNamePrefix: "gh",
 	githubToken: "ghp_123",
-	githubOrg: "xmtp",
 	coderGithubUsername: "xmtp-coder-agent",
 };
 

--- a/src/handlers/create-task.test.ts
+++ b/src/handlers/create-task.test.ts
@@ -17,7 +17,6 @@ const baseInputs: CreateTaskInputs = {
 	coderTemplateName: "task-template",
 	coderOrganization: "default",
 	githubToken: "ghp_123",
-	githubOrg: "xmtp",
 	coderGithubUsername: "xmtp-coder-agent",
 };
 
@@ -40,7 +39,7 @@ describe("CreateTaskHandler", () => {
 
 	// AC #1: Create task and post comment
 	test("creates task and comments on issue for org member", async () => {
-		github.checkOrgMembership.mockResolvedValue(true);
+		github.checkActorPermission.mockResolvedValue(true);
 		coder.getTask.mockResolvedValue(null);
 		coder.createTask.mockResolvedValue(mockTask);
 
@@ -58,9 +57,9 @@ describe("CreateTaskHandler", () => {
 		expect(github.commentOnIssue).toHaveBeenCalledTimes(1);
 	});
 
-	// AC #2: Non-org member rejected
-	test("skips for non-org member", async () => {
-		github.checkOrgMembership.mockResolvedValue(false);
+	// AC #2: Unauthorized actor rejected
+	test("skips for actor without write access", async () => {
+		github.checkActorPermission.mockResolvedValue(false);
 
 		const handler = new CreateTaskHandler(
 			coder,
@@ -71,13 +70,13 @@ describe("CreateTaskHandler", () => {
 		const result = await handler.run();
 
 		expect(result.skipped).toBe(true);
-		expect(result.skipReason).toBe("non-org-member");
+		expect(result.skipReason).toBe("insufficient-permissions");
 		expect(coder.createTask).not.toHaveBeenCalled();
 	});
 
 	// AC #4: Issue URL appended to prompt
 	test("appends issue URL to prompt", async () => {
-		github.checkOrgMembership.mockResolvedValue(true);
+		github.checkActorPermission.mockResolvedValue(true);
 		coder.getTask.mockResolvedValue(null);
 		coder.createTask.mockResolvedValue(mockTask);
 
@@ -103,7 +102,7 @@ describe("CreateTaskHandler", () => {
 
 	// AC #4: Default prompt when none provided
 	test("uses default prompt when none provided", async () => {
-		github.checkOrgMembership.mockResolvedValue(true);
+		github.checkActorPermission.mockResolvedValue(true);
 		coder.getTask.mockResolvedValue(null);
 		coder.createTask.mockResolvedValue(mockTask);
 
@@ -124,7 +123,7 @@ describe("CreateTaskHandler", () => {
 
 	// AC #5: Existing running task
 	test("skips creation when task already running", async () => {
-		github.checkOrgMembership.mockResolvedValue(true);
+		github.checkActorPermission.mockResolvedValue(true);
 		coder.getTask.mockResolvedValue(mockTask as never);
 
 		const handler = new CreateTaskHandler(
@@ -142,7 +141,7 @@ describe("CreateTaskHandler", () => {
 
 	// AC #6: Existing stopped task — restart
 	test("restarts stopped task", async () => {
-		github.checkOrgMembership.mockResolvedValue(true);
+		github.checkActorPermission.mockResolvedValue(true);
 		coder.getTask.mockResolvedValue(mockStoppedTask as never);
 
 		const handler = new CreateTaskHandler(
@@ -160,7 +159,7 @@ describe("CreateTaskHandler", () => {
 
 	// AC #25: Deterministic naming
 	test("uses deterministic task name", async () => {
-		github.checkOrgMembership.mockResolvedValue(true);
+		github.checkActorPermission.mockResolvedValue(true);
 		coder.getTask.mockResolvedValue(null);
 		coder.createTask.mockResolvedValue(mockTask);
 

--- a/src/handlers/create-task.ts
+++ b/src/handlers/create-task.ts
@@ -25,16 +25,17 @@ export class CreateTaskHandler {
 	) {}
 
 	async run(): Promise<ActionOutputs> {
-		// 1. Validate org membership
-		const isMember = await this.github.checkOrgMembership(
-			this.inputs.githubOrg,
+		// 1. Validate actor has write access to the repo
+		const hasAccess = await this.github.checkActorPermission(
+			this.context.owner,
+			this.context.repo,
 			this.context.senderLogin,
 		);
-		if (!isMember) {
+		if (!hasAccess) {
 			core.error(
-				`Actor ${this.context.senderLogin} is not a member of ${this.inputs.githubOrg}, skipping task creation`,
+				`Actor ${this.context.senderLogin} does not have write access to ${this.context.owner}/${this.context.repo}, skipping task creation`,
 			);
-			return { skipped: true, skipReason: "non-org-member" };
+			return { skipped: true, skipReason: "insufficient-permissions" };
 		}
 
 		// 2. Compute task name

--- a/src/handlers/failed-check.test.ts
+++ b/src/handlers/failed-check.test.ts
@@ -15,7 +15,6 @@ const baseInputs: FailedCheckInputs = {
 	coderUsername: "coder-agent",
 	coderTaskNamePrefix: "gh",
 	githubToken: "ghp_123",
-	githubOrg: "xmtp",
 	coderGithubUsername: "xmtp-coder-agent",
 };
 

--- a/src/handlers/issue-comment.test.ts
+++ b/src/handlers/issue-comment.test.ts
@@ -16,7 +16,6 @@ const baseInputs: IssueCommentInputs = {
 	coderUsername: "coder-agent",
 	coderTaskNamePrefix: "gh",
 	githubToken: "ghp_123",
-	githubOrg: "xmtp",
 	coderGithubUsername: "xmtp-coder-agent",
 };
 

--- a/src/handlers/pr-comment.test.ts
+++ b/src/handlers/pr-comment.test.ts
@@ -16,7 +16,6 @@ const baseInputs: PRCommentInputs = {
 	coderUsername: "coder-agent",
 	coderTaskNamePrefix: "gh",
 	githubToken: "ghp_123",
-	githubOrg: "xmtp",
 	coderGithubUsername: "xmtp-coder-agent",
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,8 @@ async function run(): Promise<void> {
 			coderTemplatePreset: core.getInput("coder-template-preset") || undefined,
 			coderOrganization: core.getInput("coder-organization") || undefined,
 			prompt: core.getInput("prompt") || undefined,
-			githubToken: core.getInput("github-token", { required: true }),
-			githubOrg: core.getInput("github-org") || undefined,
+			githubToken:
+				core.getInput("github-token") || process.env.GITHUB_TOKEN || "",
 			coderGithubUsername: core.getInput("coder-github-username") || undefined,
 		};
 

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -13,7 +13,6 @@ describe("parseInputs", () => {
 		coderUsername: "coder-agent",
 		coderTaskNamePrefix: "gh",
 		githubToken: "ghp_123",
-		githubOrg: "xmtp",
 		coderGithubUsername: "xmtp-coder-agent",
 	};
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -8,7 +8,6 @@ const BaseInputsSchema = z.object({
 	coderUsername: z.string().min(1).default("xmtp-coder-agent"),
 	coderTaskNamePrefix: z.string().min(1).default("gh"),
 	githubToken: z.string().min(1),
-	githubOrg: z.string().min(1).default("xmtp"),
 	coderGithubUsername: z.string().min(1).default("xmtp-coder-agent"),
 });
 

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -78,7 +78,7 @@ export function createMockGitHubClient(): {
 	[K in keyof GitHubClient]: ReturnType<typeof mock>;
 } {
 	return {
-		checkOrgMembership: mock(() => Promise.resolve(true)),
+		checkActorPermission: mock(() => Promise.resolve(true)),
 		findLinkedIssues: mock(() =>
 			Promise.resolve([
 				{


### PR DESCRIPTION
## Summary

Fixes "Actor neekolas is not a member of xmtp, skipping task creation" — the org membership API requires `read:org` scope which `${{ github.token }}` doesn't have, so all users appeared as non-members.

**Root cause:** `GET /orgs/{org}/members/{username}` returns 404 when the token lacks `read:org` scope, and our code treated 404 as "not a member".

**Fix:** Replace org membership check with **repo collaborator permission check** (`GET /repos/{owner}/{repo}/collaborators/{username}/permission`), which works with the default `GITHUB_TOKEN`. Users with `write` or `admin` access are allowed to create tasks.

### Changes

- **`github-client.ts`**: Replace `checkOrgMembership()` with `checkActorPermission(owner, repo, username)` using `repos.getCollaboratorPermissionLevel`
- **`create-task.ts`**: Call `checkActorPermission` with repo owner/name instead of org name
- **`action.yml`**: Remove `github-org` input; make `github-token` optional (falls back to `GITHUB_TOKEN` env var)
- **`schemas.ts`**: Remove `githubOrg` field
- **`index.ts`**: Remove `github-org` input parsing; add `GITHUB_TOKEN` env fallback
- **Tests**: 77 pass (4 new permission check tests, updated handler tests)
- **README**: Updated inputs table, permission docs, removed `github-org`

## Test plan

- [ ] 77 tests pass
- [ ] Assigning an issue to `xmtp-coder-agent` by an org member with write access creates a task
- [ ] `github-token` is auto-detected from environment when not explicitly passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix permission check to use repo write access instead of org membership
> - Replaces `GitHubClient.checkOrgMembership` with `checkActorPermission`, which calls `repos.getCollaboratorPermissionLevel` and returns `true` only for `admin` or `write` permissions.
> - Removes the `github-org` input from the action entirely; the `github-token` input now defaults to the workflow's `GITHUB_TOKEN` environment variable.
> - Updates the skip reason from `non-org-member` to `insufficient-permissions` in `CreateTaskHandler`.
> - Behavioral Change: Users relying on org membership as the permission gate will now require repo write access instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 91c3deb. 14 files reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/index.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 35](https://github.com/xmtplabs/coder-action/blob/91c3deb7998555d64b00266930c0c3c9697955ef/src/index.ts#L35): If neither the `github-token` input nor the `GITHUB_TOKEN` environment variable is set, `githubToken` will be an empty string `""`. This empty string will pass to `github.getOctokit(inputs.githubToken)` on line 45, which will either create a non-functional unauthenticated client or fail with a confusing authentication error when any handler attempts API calls. The previous code used `{ required: true }` to fail early with a clear message. Unless `parseInputs` validates that `githubToken` is non-empty, users who forget to configure the token will get obscure errors instead of a clear input validation failure. <b>[ Failed validation ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->