### PR TITLE
fix: remove default prompt, use only issue URL when no prompt provided

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26411,8 +26411,6 @@ async function lookupAndEnsureActiveTask(coder, coderUsername, taskName) {
 }
 
 // src/handlers/create-task.ts
-var DEFAULT_PROMPT = "Resolve the GitHub issue linked below. Read the issue, develop a plan, post it as a comment, then implement and open a PR.";
-
 class CreateTaskHandler {
   coder;
   github;
@@ -26447,10 +26445,9 @@ class CreateTaskHandler {
         skipped: false
       };
     }
-    const promptText = this.inputs.prompt ?? DEFAULT_PROMPT;
-    const fullPrompt = `${promptText}
+    const fullPrompt = this.inputs.prompt ? `${this.inputs.prompt}
 
-${this.context.issueUrl}`;
+${this.context.issueUrl}` : this.context.issueUrl;
     const template = await this.coder.getTemplateByOrganizationAndName(this.inputs.coderOrganization, this.inputs.coderTemplateName);
     const presets = await this.coder.getTemplateVersionPresets(template.active_version_id);
     let presetId;

--- a/src/handlers/create-task.test.ts
+++ b/src/handlers/create-task.test.ts
@@ -100,8 +100,8 @@ describe("CreateTaskHandler", () => {
 		);
 	});
 
-	// AC #4: Default prompt when none provided
-	test("uses default prompt when none provided", async () => {
+	// AC #4: Only issue URL when no prompt provided
+	test("uses only issue URL when no prompt provided", async () => {
 		github.checkActorPermission.mockResolvedValue(true);
 		coder.getTask.mockResolvedValue(null);
 		coder.createTask.mockResolvedValue(mockTask);
@@ -118,7 +118,7 @@ describe("CreateTaskHandler", () => {
 			string,
 			{ input: string },
 		];
-		expect(createCall[1].input).toContain(issueContext.issueUrl);
+		expect(createCall[1].input).toBe(issueContext.issueUrl);
 	});
 
 	// AC #5: Existing running task

--- a/src/handlers/create-task.ts
+++ b/src/handlers/create-task.ts
@@ -13,9 +13,6 @@ export interface IssueContext {
 	senderLogin: string;
 }
 
-const DEFAULT_PROMPT =
-	"Resolve the GitHub issue linked below. Read the issue, develop a plan, post it as a comment, then implement and open a PR.";
-
 export class CreateTaskHandler {
 	constructor(
 		private readonly coder: CoderClient,
@@ -79,8 +76,9 @@ export class CreateTaskHandler {
 		}
 
 		// 4. Build prompt
-		const promptText = this.inputs.prompt ?? DEFAULT_PROMPT;
-		const fullPrompt = `${promptText}\n\n${this.context.issueUrl}`;
+		const fullPrompt = this.inputs.prompt
+			? `${this.inputs.prompt}\n\n${this.context.issueUrl}`
+			: this.context.issueUrl;
 
 		// 5. Get template and create task
 		const template = await this.coder.getTemplateByOrganizationAndName(


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/6

## Summary

- Removed the `DEFAULT_PROMPT` constant from `create-task.ts`
- When no user-defined prompt is provided, the task input is now just the issue URL (instead of the boilerplate default text + issue URL)
- When a prompt is provided, behavior is unchanged: prompt text is prepended to the issue URL
- Updated the corresponding test to assert the input equals the issue URL exactly when no prompt is given

## Test plan

- [ ] All 76 existing tests pass (`bun test`)
- [ ] Typecheck passes (`tsc --noEmit`)
- [ ] Lint passes (`biome lint`)
- [ ] Format check passes (`biome format`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove default prompt from task creation, using only issue URL when no prompt is provided
> Previously, `CreateTaskHandler` fell back to a hardcoded `DEFAULT_PROMPT` string when no prompt was supplied. Now, if no prompt is provided, the task input is set to just the issue URL; if a prompt is provided, it is joined with the issue URL separated by a blank line.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95ece3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->