### PR TITLE
fix: enforce xmtplabs org membership before creating Coder tasks

### DIFF
--- a/.github/workflows/coder.yml
+++ b/.github/workflows/coder.yml
@@ -19,6 +19,10 @@ jobs:
       && github.event.action == 'assigned'
       && github.event.assignee.login == 'xmtp-coder-agent'
     steps:
+      - name: Check creator is xmtplabs member
+        run: gh api orgs/xmtplabs/members/${{ github.event.issue.user.login }} --silent
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Create Coder Task
         uses: xmtplabs/coder-action@main
         with:


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/2

## Summary

- Adds a `Check creator is xmtplabs member` step to the `create-task` job in `coder.yml`
- Uses `gh api orgs/xmtplabs/members/<username>` which returns 204 for members and fails (404) for non-members
- If the issue creator is not in the `xmtplabs` org, the step fails and the Coder task is never created

## Test plan

- [ ] Verify the workflow runs successfully when an `xmtplabs` org member opens an issue and assigns `xmtp-coder-agent`
- [ ] Verify the workflow fails at the membership check step when a non-member opens an issue and assigns `xmtp-coder-agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce xmtplabs org membership before creating Coder tasks in CI
> Adds a preflight step to the `create-task` job in [coder.yml](.github/workflows/coder.yml) that calls `gh api orgs/xmtplabs/members/{user}` to verify the issue creator is an xmtplabs org member. If the check fails, the job stops and the Coder task is never created.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 02c0fca. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->