### PR TITLE
ci: improve dist freshness check to cover entire dist/ folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Verify dist/index.js is up to date
+      - name: Verify dist is up to date
         run: |
-          git diff --exit-code dist/index.js || {
-            echo "::error::dist/index.js is out of date. Run 'bun run build' and commit the result."
+          if [ -n "$(git status --porcelain dist/)" ]; then
+            echo "::error::dist/ is out of date. Run 'bun run build' and commit the result."
             exit 1
-          }
+          fi


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/8

## Summary

The CI check for dist freshness already existed in `.github/workflows/ci.yml`, but used `git diff --exit-code dist/index.js` which only detects changes to a single tracked file.

This PR improves the check by switching to `git status --porcelain dist/` which:
- Checks the entire `dist/` folder (not just `dist/index.js`)
- Also detects new untracked files that may be added to `dist/` in the future
- Produces a cleaner, more idiomatic shell conditional

## Changes

- Rename step from "Verify dist/index.js is up to date" → "Verify dist is up to date"
- Replace `git diff --exit-code dist/index.js` with `git status --porcelain dist/` check

## Test plan

- [x] CI workflow syntax is valid YAML
- [x] `biome format:check` passes (YAML files are not processed by Biome, no issues)
- [x] The check will fail if `dist/` has any uncommitted changes after `bun run build`
- [x] The check will pass if `dist/` is clean after building

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand CI dist freshness check to cover entire `dist/` folder
> Previously, the CI check only verified `dist/index.js` was up to date using `git diff --exit-code`. It now uses `git status --porcelain dist/` to detect uncommitted changes across all files in `dist/`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7ee5f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->