### PR TITLE
fix: add github-token to close-task, pr-comment, and issue-comment steps

### DIFF
--- a/.github/workflows/coder.yml
+++ b/.github/workflows/coder.yml
@@ -40,6 +40,7 @@ jobs:
           action: close_task
           coder-url: ${{ secrets.CODER_URL }}
           coder-token: ${{ secrets.CODER_TOKEN }}
+          github-token: ${{ github.token }}
 
   pr-comment:
     runs-on: ubuntu-latest
@@ -56,6 +57,7 @@ jobs:
           action: pr_comment
           coder-url: ${{ secrets.CODER_URL }}
           coder-token: ${{ secrets.CODER_TOKEN }}
+          github-token: ${{ github.token }}
 
   issue-comment:
     runs-on: ubuntu-latest
@@ -71,3 +73,4 @@ jobs:
           action: issue_comment
           coder-url: ${{ secrets.CODER_URL }}
           coder-token: ${{ secrets.CODER_TOKEN }}
+          github-token: ${{ github.token }}


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/10

## Summary

- The `close-task`, `pr-comment`, and `issue-comment` steps in `.github/workflows/coder.yml` were missing `github-token: ${{ github.token }}`
- Without it, `core.getInput("github-token")` returns an empty string and `process.env.GITHUB_TOKEN` is not set in the runner environment, so `githubToken` ends up as `""`
- The Zod schema requires `githubToken` to be at least 1 character, causing validation to fail
- The `create-task` step and `examples/workflows/coder.yml` already passed `github-token` correctly; this brings the main workflow in sync

## Test plan

- [x] All 76 existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] The fix matches the pattern already used in `create-task` and `examples/workflows/coder.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)