### PR TITLE
fix: add default ${{ github.token }} to github-token input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,7 @@ inputs:
   github-token:
     description: "GitHub token for API operations. Defaults to the workflow's GITHUB_TOKEN."
     required: false
+    default: ${{ github.token }}
   coder-github-username:
     description: "GitHub username of the designated coder agent"
     required: false


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/12

## Summary

- The `github-token` input in `action.yml` was `required: false` with no `default` value
- The fallback in `index.ts` (`process.env.GITHUB_TOKEN`) is ineffective because `GITHUB_TOKEN` is **not** automatically injected as an environment variable in GitHub Actions runners
- When callers omit `github-token`, the token evaluates to `""`, which fails the Zod schema validation `z.string().min(1)` — causing the `close_task` (and other) actions to fail immediately

## Fix

Add `default: ${{ github.token }}` to the `github-token` input in `action.yml`, following the same pattern used by `actions/checkout` and other official GitHub Actions. This ensures the action always has a valid token even when the caller doesn't explicitly wire up `github-token`.

## Test plan

- [x] All 76 existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Build succeeds (`bun run build`)
- [x] The `default: ${{ github.token }}` pattern is validated by `actions/checkout` precedent