### PR TITLE
fix: update task comment on close to remove URL and state completion

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26515,7 +26515,7 @@ class CloseTaskHandler {
     } catch (error2) {
       warning(`Failed to delete workspace: ${error2}`);
     }
-    await this.github.commentOnIssue(this.context.owner, this.context.repo, this.context.issueNumber, `Coder task ${taskName} cleaned up.`, "Coder task");
+    await this.github.commentOnIssue(this.context.owner, this.context.repo, this.context.issueNumber, "Task completed.", "Task created:");
     return { taskName, taskStatus: "deleted", skipped: false };
   }
 }

--- a/src/handlers/close-task.test.ts
+++ b/src/handlers/close-task.test.ts
@@ -52,7 +52,13 @@ describe("CloseTaskHandler", () => {
 		expect(result.skipped).toBe(false);
 		expect(coder.stopWorkspace).toHaveBeenCalledWith("ws-1");
 		expect(coder.deleteWorkspace).toHaveBeenCalledWith("ws-1");
-		expect(github.commentOnIssue).toHaveBeenCalledTimes(1);
+		expect(github.commentOnIssue).toHaveBeenCalledWith(
+			closeContext.owner,
+			closeContext.repo,
+			closeContext.issueNumber,
+			"Task completed.",
+			"Task created:",
+		);
 	});
 
 	// AC #8: No task found

--- a/src/handlers/close-task.ts
+++ b/src/handlers/close-task.ts
@@ -61,8 +61,8 @@ export class CloseTaskHandler {
 			this.context.owner,
 			this.context.repo,
 			this.context.issueNumber,
-			`Coder task ${taskName} cleaned up.`,
-			"Coder task",
+			"Task completed.",
+			"Task created:",
 		);
 
 		return { taskName, taskStatus: "deleted", skipped: false };


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/14

## Summary

- When a Coder task is destroyed after an issue is closed, the original `Task created: <url>` comment is now **updated in-place** to say `Task completed.`
- This removes the dead task link and clearly communicates the task is done
- Uses the existing `commentOnIssue` method's prefix-matching to find and update the original comment (matchPrefix: `"Task created:"`)

## Changes

- `src/handlers/close-task.ts`: Updated `commentOnIssue` call to use `"Task completed."` as body and `"Task created:"` as matchPrefix
- `src/handlers/close-task.test.ts`: Updated test assertion to verify correct message and prefix
- `dist/index.js`: Rebuilt bundle

## Test plan

- [x] All 76 existing tests pass
- [x] TypeScript type checks pass
- [x] Biome lint and format checks pass
- [x] Updated test asserts `commentOnIssue` is called with `"Task completed."` and `"Task created:"` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update task close comment to say 'Task completed.' in `CloseTaskHandler`
> Changes the comment posted on a GitHub issue when a task is closed. The body is now `'Task completed.'` and the category label is `'Task created:'`, replacing the previous interpolated message `'Coder task ${taskName} cleaned up.'` and category `'Task created'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 589ebb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->