### PR TITLE
fix: remove empty prompt from coder.yml workflow

### DIFF
--- a/.github/workflows/coder.yml
+++ b/.github/workflows/coder.yml
@@ -30,7 +30,6 @@ jobs:
           coder-url: ${{ secrets.CODER_URL }}
           coder-token: ${{ secrets.CODER_TOKEN }}
           github-token: ${{ github.token }}
-          prompt: " "
 
   close-task:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/26

## Changes

Removes the unnecessary `prompt: " "` (whitespace-only string) from the `create-task` job in `.github/workflows/coder.yml`.

Since `prompt` is an optional input in `action.yml`, omitting it is equivalent and cleaner. All workflow inputs remain valid.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove empty `prompt` input from `create-task` job in coder.yml workflow
> Removes the `prompt: " "` input from the `Create Coder Task` step in [coder.yml](.github/workflows/coder.yml), so the `xmtplabs/coder-action` runs without an explicit prompt argument instead of receiving a blank string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27bde64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->