### PR TITLE
fix: remove duplicate 👀 reaction instructions from LLM prompts

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26551,8 +26551,6 @@ function formatPRCommentMessage(params) {
 Commenter: ${params.commenter}
 Timestamp: ${params.timestamp}
 
-Immediately react to the comment with \uD83D\uDC40 emoji to show you have seen it.
-
 Validate whether the comment is useful feedback to improve the quality of the task output.
 
 For all valid suggestions in the comment, implement them, ensure the branch is still in a healthy state (all lint and tests continue to pass), then commit and push. Reply to the comment with a succinct and clear explanation of the changes you made.
@@ -26573,7 +26571,6 @@ Review this comment on the issue you are working on. If it contains new requirem
 
 If the comment asks a question, reply directly on the issue.
 
-React to the comment with \uD83D\uDC40 emoji to acknowledge you have seen it.
 ---
 
 ${params.body}`;

--- a/src/messages.test.ts
+++ b/src/messages.test.ts
@@ -18,7 +18,6 @@ describe("formatPRCommentMessage", () => {
 		);
 		expect(msg).toContain("Commenter: reviewer");
 		expect(msg).toContain("Timestamp: 2026-03-17T12:00:00Z");
-		expect(msg).toContain("react to the comment with 👀");
 		expect(msg).toContain("Please fix the typo on line 42");
 	});
 });

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -27,8 +27,6 @@ export function formatPRCommentMessage(params: PRCommentParams): string {
 Commenter: ${params.commenter}
 Timestamp: ${params.timestamp}
 
-Immediately react to the comment with 👀 emoji to show you have seen it.
-
 Validate whether the comment is useful feedback to improve the quality of the task output.
 
 For all valid suggestions in the comment, implement them, ensure the branch is still in a healthy state (all lint and tests continue to pass), then commit and push. Reply to the comment with a succinct and clear explanation of the changes you made.
@@ -50,7 +48,6 @@ Review this comment on the issue you are working on. If it contains new requirem
 
 If the comment asks a question, reply directly on the issue.
 
-React to the comment with 👀 emoji to acknowledge you have seen it.
 ---
 
 ${params.body}`;


### PR DESCRIPTION
## Summary

- Removes `react to the comment with 👀` instructions from `formatPRCommentMessage` and `formatIssueCommentMessage` in `messages.ts`
- The action already adds the eyes reaction at the GitHub workflow level (in both `pr-comment.ts` and `issue-comment.ts`), causing the reaction to appear twice
- Updated the test in `messages.test.ts` to remove the assertion for the now-removed instruction

## Test plan

- [x] All 83 existing tests pass (`bun run check`)
- [x] The `formatPRCommentMessage` test no longer asserts for the removed 👀 instruction
- [x] Both handlers (`IssueCommentHandler`, `PRCommentHandler`) still add the reaction via `github.addReactionToComment()`

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove duplicate 👀 reaction instructions from `formatPRCommentMessage` output
> Deletes two duplicate lines from the message template in [messages.ts](https://github.com/xmtplabs/coder-action/pull/33/files#diff-46bbb95b17ce5a3865ddffffb0fb655706c57eeb0b4a0d5fee7b2a4ed6564723) that instructed readers to react to the comment with the 👀 emoji. The corresponding test assertion in [messages.test.ts](https://github.com/xmtplabs/coder-action/pull/33/files#diff-891bf92ca588f221a23eb2d8c83f1ab6ba92978bc9e021d1672debe5c20d84ac) is also removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8de7ec9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->