### PR TITLE
fix: remove duplicate 👀 reaction instructions from LLM messages

### DIFF
--- a/src/messages.test.ts
+++ b/src/messages.test.ts
@@ -18,7 +18,6 @@ describe("formatPRCommentMessage", () => {
 		);
 		expect(msg).toContain("Commenter: reviewer");
 		expect(msg).toContain("Timestamp: 2026-03-17T12:00:00Z");
-		expect(msg).toContain("react to the comment with 👀");
 		expect(msg).toContain("Please fix the typo on line 42");
 	});
 });

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -27,8 +27,6 @@ export function formatPRCommentMessage(params: PRCommentParams): string {
 Commenter: ${params.commenter}
 Timestamp: ${params.timestamp}
 
-Immediately react to the comment with 👀 emoji to show you have seen it.
-
 Validate whether the comment is useful feedback to improve the quality of the task output.
 
 For all valid suggestions in the comment, implement them, ensure the branch is still in a healthy state (all lint and tests continue to pass), then commit and push. Reply to the comment with a succinct and clear explanation of the changes you made.
@@ -49,8 +47,6 @@ Timestamp: ${params.timestamp}
 Review this comment on the issue you are working on. If it contains new requirements, clarifications, or feedback that affects your current work, adjust your approach accordingly.
 
 If the comment asks a question, reply directly on the issue.
-
-React to the comment with 👀 emoji to acknowledge you have seen it.
 ---
 
 ${params.body}`;


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/31

## Summary

- Removed "Immediately react to the comment with 👀 emoji" instruction from `formatPRCommentMessage`
- Removed "React to the comment with 👀 emoji to acknowledge you have seen it." instruction from `formatIssueCommentMessage`
- Updated corresponding test that was asserting on the removed instruction

The GitHub Action already handles adding the 👀 reaction via `addReactionToComment()` in both `IssueCommentHandler` and `PRCommentHandler`, so the LLM instructions were causing duplicate reactions.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove duplicate 👀 reaction instructions from LLM PR and issue comment messages
> Removes a redundant instruction line telling the reader to react with the 👀 emoji from both the PR comment and issue comment message formatters in [messages.ts](https://github.com/xmtplabs/coder-action/pull/34/files#diff-46bbb95b17ce5a3865ddffffb0fb655706c57eeb0b4a0d5fee7b2a4ed6564723). The corresponding test in [messages.test.ts](https://github.com/xmtplabs/coder-action/pull/34/files#diff-891bf92ca588f221a23eb2d8c83f1ab6ba92978bc9e021d1672debe5c20d84ac) is updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61dc201.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->