### PR TITLE
fix: add pull-requests: write permission for PR comment reactions

### DIFF
--- a/.github/workflows/coder.yml
+++ b/.github/workflows/coder.yml
@@ -12,7 +12,7 @@ on:
 permissions:
   actions: read
   issues: write
-  pull-requests: read
+  pull-requests: write
   contents: read
 
 jobs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -26349,12 +26349,16 @@ class GitHubClient {
 `);
   }
   async addReactionToComment(owner, repo, commentId) {
-    await this.octokit.rest.reactions.createForIssueComment({
-      owner,
-      repo,
-      comment_id: commentId,
-      content: "eyes"
-    });
+    try {
+      await this.octokit.rest.reactions.createForIssueComment({
+        owner,
+        repo,
+        comment_id: commentId,
+        content: "eyes"
+      });
+    } catch (error2) {
+      warning(`Failed to add reaction to comment ${commentId}: ${error2 instanceof Error ? error2.message : String(error2)}`);
+    }
   }
 }
 

--- a/docs/plans/2026-03-19-issue-35-design.md
+++ b/docs/plans/2026-03-19-issue-35-design.md
@@ -1,0 +1,75 @@
+# Issue #35: Failed issue comment run — Design
+
+## Problem
+
+The `pr-comment` job fails with:
+```
+Resource not accessible by integration
+https://docs.github.com/rest/reactions/reactions#create-reaction-for-an-issue-comment
+```
+
+The action successfully forwards the PR comment to the Coder task but then crashes when
+trying to add an "eyes" reaction (`👀`) to the comment. The GitHub REST API endpoint
+`POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions` requires
+`pull-requests: write` permission when the comment is on a pull request. The current
+workflow only grants `pull-requests: read`.
+
+## Root Cause
+
+Both workflow files set:
+```yaml
+permissions:
+  pull-requests: read   # insufficient for reaction on PR comments
+```
+
+The `addReactionToComment` helper in `github-client.ts` calls
+`octokit.rest.reactions.createForIssueComment`, which requires `pull-requests: write`
+for comments that belong to a pull request.
+
+## EARS Requirements
+
+- **REQ-1**: When: the `pr-comment` action handler successfully forwards a comment,
+  Then: the system SHALL add an "eyes" reaction to the comment without error.
+- **REQ-2**: The `pr-comment` workflow job SHALL be granted `pull-requests: write`
+  permission so it can add reactions to PR comments.
+- **REQ-3**: The example workflow (`examples/workflows/coder.yml`) SHALL reflect the
+  same updated permission to keep it consistent with the real workflow.
+- **REQ-4 (resilience)**: When adding a reaction fails (e.g. insufficient permissions
+  or network error), the action SHALL log a warning and complete successfully rather
+  than marking the run as failed, because the primary operation (forwarding the comment)
+  already succeeded.
+
+## System Design
+
+### Change 1 — Workflow permissions (`.github/workflows/coder.yml`)
+
+```yaml
+permissions:
+  actions: read
+  issues: write
+  pull-requests: write   # changed from read
+  contents: read
+```
+
+### Change 2 — Example workflow (`examples/workflows/coder.yml`)
+
+Same permission change as Change 1.
+
+### Change 3 — Resilient reaction (`src/github-client.ts`)
+
+Wrap the `createForIssueComment` call in a try/catch. On failure, log a warning via
+`core.warning` rather than throwing. This way the action never fails solely because of a
+reaction error.
+
+Note: both `pr-comment.ts` and `issue-comment.ts` call `addReactionToComment`; making
+the client method itself resilient handles both call sites without duplicating
+error-handling logic.
+
+## Testing & Validation
+
+- Existing unit tests for `PRCommentHandler` and `IssueCommentHandler` must remain
+  green.
+- Add a unit test for `addReactionToComment` in `github-client.ts` that verifies:
+  - when the API throws, the method does NOT re-throw (resilience).
+- `bun run check` (typecheck + lint + format + test) must pass.
+- `bun run build` must succeed and `dist/index.js` must be updated.

--- a/examples/workflows/coder.yml
+++ b/examples/workflows/coder.yml
@@ -14,7 +14,7 @@ on:
 permissions:
   actions: read
   issues: write
-  pull-requests: read
+  pull-requests: write
   contents: read
 
 jobs:

--- a/src/github-client.test.ts
+++ b/src/github-client.test.ts
@@ -261,6 +261,20 @@ describe("GitHubClient", () => {
 				},
 			);
 		});
+
+		test("does not throw when reaction API fails", async () => {
+			const octokit = createMockOctokit({
+				reactions: {
+					createForIssueComment: mock(() =>
+						Promise.reject(new Error("Resource not accessible by integration")),
+					),
+				},
+			});
+			const client = new GitHubClient(octokit);
+			await expect(
+				client.addReactionToComment("org", "repo", 42),
+			).resolves.toBeUndefined();
+		});
 	});
 
 	describe("getJobLogs", () => {

--- a/src/github-client.ts
+++ b/src/github-client.ts
@@ -1,3 +1,4 @@
+import * as core from "@actions/core";
 import type { getOctokit } from "@actions/github";
 
 export type Octokit = ReturnType<typeof getOctokit>;
@@ -190,11 +191,17 @@ export class GitHubClient {
 		repo: string,
 		commentId: number,
 	): Promise<void> {
-		await this.octokit.rest.reactions.createForIssueComment({
-			owner,
-			repo,
-			comment_id: commentId,
-			content: "eyes",
-		});
+		try {
+			await this.octokit.rest.reactions.createForIssueComment({
+				owner,
+				repo,
+				comment_id: commentId,
+				content: "eyes",
+			});
+		} catch (error: unknown) {
+			core.warning(
+				`Failed to add reaction to comment ${commentId}: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/35

## Root Cause

The `pr-comment` job was failing with:
```
Resource not accessible by integration
```

after successfully forwarding a PR comment to the Coder task. The action then tried to add an 👀 reaction to the comment, but the GitHub reactions API requires `pull-requests: write` for comments on pull requests. Both workflow files only granted `pull-requests: read`.

## Changes

- **`.github/workflows/coder.yml`** — upgrade `pull-requests: read` → `pull-requests: write`
- **`examples/workflows/coder.yml`** — same permission upgrade for consistency
- **`src/github-client.ts`** — wrap `addReactionToComment` in try/catch so a reaction failure emits a warning instead of failing the whole action (the comment was already forwarded successfully)
- **`src/github-client.test.ts`** — add test verifying the resilience behavior
- **`dist/index.js`** — rebuilt bundle

## Test plan

- [x] All 84 existing tests pass (`bun test`)
- [x] New test: `addReactionToComment` does not throw when the API returns an error
- [x] `bun run check` (typecheck + lint + format:check + test) passes
- [x] `bun run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix PR comment reaction failures by adding `pull-requests: write` permission and making `addReactionToComment` resilient
> - Updates `pull-requests` permission from `read` to `write` in both [coder.yml](https://github.com/xmtplabs/coder-action/pull/36/files#diff-37baee1dce648a8ca1571781944ce8f45989129a6b66c5a6d0cbec12ea1269a6) and [examples/workflows/coder.yml](https://github.com/xmtplabs/coder-action/pull/36/files#diff-341da91252091d1072a3771aa811eca660296fcd32e2a7e2cf2ebc6b30a81d0f) so the GitHub Actions token can add reactions to PR comments.
> - Wraps the `octokit.rest.reactions.createForIssueComment` call in [github-client.ts](https://github.com/xmtplabs/coder-action/pull/36/files#diff-c094aa4c4c6d21a71d1f314fd395120c88b23c6e14b99427d8dc7409eb1ceb93) in a try/catch; on failure, logs a warning via `core.warning` instead of throwing.
> - Behavioral Change: `addReactionToComment` no longer propagates errors from the reactions API, so a failed reaction will not fail the workflow step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4dd8376.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->