### PR TITLE
fix: wait for workspace to stop before deleting to prevent paused tasks

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26221,6 +26221,26 @@ class RealCoderClient {
       body: JSON.stringify({ transition: "stop" })
     });
   }
+  async waitForWorkspaceStopped(workspaceId, logFn, timeoutMs = 120000) {
+    const terminalStatuses = new Set([
+      "stopped",
+      "failed",
+      "canceled",
+      "deleted"
+    ]);
+    const startTime = Date.now();
+    const pollIntervalMs = 2000;
+    while (Date.now() - startTime < timeoutMs) {
+      const workspace = await this.getWorkspace(workspaceId);
+      const status = workspace.latest_build.status;
+      logFn(`waitForWorkspaceStopped: workspace_id: ${workspaceId} status: ${status}`);
+      if (terminalStatuses.has(status)) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+    throw new CoderAPIError(`Timeout waiting for workspace to stop (waited ${timeoutMs}ms)`, 408);
+  }
   async deleteWorkspace(workspaceId) {
     await this.request(`/api/v2/workspaces/${encodeURIComponent(workspaceId)}/builds`, {
       method: "POST",
@@ -26528,10 +26548,19 @@ class CloseTaskHandler {
     }
     const workspaceId = task.workspace_id;
     info(`Stopping workspace ${workspaceId} for task ${taskName}`);
+    let stopSucceeded = false;
     try {
       await this.coder.stopWorkspace(workspaceId);
+      stopSucceeded = true;
     } catch (error2) {
       warning(`Failed to stop workspace: ${error2}`);
+    }
+    if (stopSucceeded) {
+      try {
+        await this.coder.waitForWorkspaceStopped(workspaceId, info);
+      } catch (error2) {
+        warning(`Timed out waiting for workspace to stop: ${error2}`);
+      }
     }
     try {
       await this.coder.deleteWorkspace(workspaceId);

--- a/src/coder-client.test.ts
+++ b/src/coder-client.test.ts
@@ -148,4 +148,60 @@ describe("RealCoderClient", () => {
 			expect(client.getWorkspace("ws-id")).rejects.toThrow(CoderAPIError);
 		});
 	});
+
+	describe("waitForWorkspaceStopped", () => {
+		test("resolves immediately when workspace is already stopped", async () => {
+			const ws = {
+				id: "ws-id",
+				latest_build: { status: "stopped", transition: "stop" },
+			};
+			mockFetch.mockResolvedValueOnce(createMockResponse(ws));
+			const logs: string[] = [];
+			await client.waitForWorkspaceStopped("ws-id", (msg) => logs.push(msg));
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+		});
+
+		test("resolves after workspace transitions to stopped", async () => {
+			const stopping = {
+				id: "ws-id",
+				latest_build: { status: "stopping", transition: "stop" },
+			};
+			const stopped = {
+				id: "ws-id",
+				latest_build: { status: "stopped", transition: "stop" },
+			};
+			mockFetch
+				.mockResolvedValueOnce(createMockResponse(stopping))
+				.mockResolvedValueOnce(createMockResponse(stopped));
+			const logs: string[] = [];
+			await client.waitForWorkspaceStopped(
+				"ws-id",
+				(msg) => logs.push(msg),
+				10000,
+			);
+			expect(mockFetch).toHaveBeenCalledTimes(2);
+		});
+
+		test("resolves when workspace reaches failed status", async () => {
+			const ws = {
+				id: "ws-id",
+				latest_build: { status: "failed", transition: "stop" },
+			};
+			mockFetch.mockResolvedValueOnce(createMockResponse(ws));
+			await client.waitForWorkspaceStopped("ws-id", () => {});
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+		});
+
+		test("throws CoderAPIError on timeout", async () => {
+			const stopping = {
+				id: "ws-id",
+				latest_build: { status: "stopping", transition: "stop" },
+			};
+			// Always return stopping so it times out
+			mockFetch.mockResolvedValue(createMockResponse(stopping));
+			await expect(
+				client.waitForWorkspaceStopped("ws-id", () => {}, 100),
+			).rejects.toThrow(CoderAPIError);
+		});
+	});
 });

--- a/src/coder-client.ts
+++ b/src/coder-client.ts
@@ -162,6 +162,11 @@ export interface CoderClient {
 	): Promise<void>;
 	getWorkspace(workspaceId: string): Promise<Workspace>;
 	stopWorkspace(workspaceId: string): Promise<void>;
+	waitForWorkspaceStopped(
+		workspaceId: string,
+		logFn: (msg: string) => void,
+		timeoutMs?: number,
+	): Promise<void>;
 	deleteWorkspace(workspaceId: string): Promise<void>;
 	deleteTask(owner: string | undefined, taskId: TaskId): Promise<void>;
 }
@@ -393,6 +398,41 @@ export class RealCoderClient implements CoderClient {
 				method: "POST",
 				body: JSON.stringify({ transition: "stop" }),
 			},
+		);
+	}
+
+	/**
+	 * waitForWorkspaceStopped polls the workspace until it reaches a terminal stopped state or times out.
+	 */
+	async waitForWorkspaceStopped(
+		workspaceId: string,
+		logFn: (msg: string) => void,
+		timeoutMs = 120000,
+	): Promise<void> {
+		const terminalStatuses = new Set([
+			"stopped",
+			"failed",
+			"canceled",
+			"deleted",
+		]);
+		const startTime = Date.now();
+		const pollIntervalMs = 2000;
+
+		while (Date.now() - startTime < timeoutMs) {
+			const workspace = await this.getWorkspace(workspaceId);
+			const status = workspace.latest_build.status;
+			logFn(
+				`waitForWorkspaceStopped: workspace_id: ${workspaceId} status: ${status}`,
+			);
+			if (terminalStatuses.has(status)) {
+				return;
+			}
+			await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+		}
+
+		throw new CoderAPIError(
+			`Timeout waiting for workspace to stop (waited ${timeoutMs}ms)`,
+			408,
 		);
 	}
 

--- a/src/handlers/close-task.test.ts
+++ b/src/handlers/close-task.test.ts
@@ -35,7 +35,7 @@ describe("CloseTaskHandler", () => {
 	});
 
 	// AC #7: Stop and delete workspace, then delete task
-	test("stops and deletes workspace and task when task exists", async () => {
+	test("stops, waits for stop, deletes workspace and task when task exists", async () => {
 		coder.getTask.mockResolvedValue({
 			...mockTask,
 			workspace_id: "ws-1",
@@ -51,6 +51,10 @@ describe("CloseTaskHandler", () => {
 
 		expect(result.skipped).toBe(false);
 		expect(coder.stopWorkspace).toHaveBeenCalledWith("ws-1");
+		expect(coder.waitForWorkspaceStopped).toHaveBeenCalledWith(
+			"ws-1",
+			expect.any(Function),
+		);
 		expect(coder.deleteWorkspace).toHaveBeenCalledWith("ws-1");
 		expect(coder.deleteTask).toHaveBeenCalledWith(
 			baseInputs.coderUsername,
@@ -79,16 +83,44 @@ describe("CloseTaskHandler", () => {
 
 		expect(result.skipped).toBe(true);
 		expect(coder.stopWorkspace).not.toHaveBeenCalled();
+		expect(coder.waitForWorkspaceStopped).not.toHaveBeenCalled();
 		expect(coder.deleteWorkspace).not.toHaveBeenCalled();
 	});
 
-	// AC #9: Stop fails, still deletes workspace and task
-	test("attempts delete even when stop fails", async () => {
+	// AC #9: Stop fails — skip wait, still delete workspace and task
+	test("skips wait and attempts delete even when stop fails", async () => {
 		coder.getTask.mockResolvedValue({
 			...mockTask,
 			workspace_id: "ws-1",
 		} as never);
 		coder.stopWorkspace.mockRejectedValue(new Error("stop failed"));
+
+		const handler = new CloseTaskHandler(
+			coder,
+			github as unknown as import("../github-client").GitHubClient,
+			baseInputs,
+			closeContext,
+		);
+		const result = await handler.run();
+
+		expect(result.skipped).toBe(false);
+		expect(coder.waitForWorkspaceStopped).not.toHaveBeenCalled();
+		expect(coder.deleteWorkspace).toHaveBeenCalledWith("ws-1");
+		expect(coder.deleteTask).toHaveBeenCalledWith(
+			baseInputs.coderUsername,
+			mockTask.id,
+		);
+	});
+
+	// waitForWorkspaceStopped times out — still delete workspace and task
+	test("attempts delete even when waitForWorkspaceStopped times out", async () => {
+		coder.getTask.mockResolvedValue({
+			...mockTask,
+			workspace_id: "ws-1",
+		} as never);
+		coder.waitForWorkspaceStopped.mockRejectedValue(
+			new CoderAPIError("Timeout waiting for workspace to stop", 408),
+		);
 
 		const handler = new CloseTaskHandler(
 			coder,

--- a/src/handlers/close-task.ts
+++ b/src/handlers/close-task.ts
@@ -44,10 +44,21 @@ export class CloseTaskHandler {
 		core.info(`Stopping workspace ${workspaceId} for task ${taskName}`);
 
 		// Stop workspace — continue even if this fails
+		let stopSucceeded = false;
 		try {
 			await this.coder.stopWorkspace(workspaceId);
+			stopSucceeded = true;
 		} catch (error) {
 			core.warning(`Failed to stop workspace: ${error}`);
+		}
+
+		// Wait for workspace to reach stopped state before deleting — continue even if this times out
+		if (stopSucceeded) {
+			try {
+				await this.coder.waitForWorkspaceStopped(workspaceId, core.info);
+			} catch (error) {
+				core.warning(`Timed out waiting for workspace to stop: ${error}`);
+			}
 		}
 
 		// Delete workspace — continue even if this fails

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -69,6 +69,7 @@ export class MockCoderClient implements CoderClient {
 		}),
 	);
 	stopWorkspace = mock(() => Promise.resolve());
+	waitForWorkspaceStopped = mock(() => Promise.resolve());
 	deleteWorkspace = mock(() => Promise.resolve());
 	deleteTask = mock(() => Promise.resolve());
 }


### PR DESCRIPTION
## Summary

- `stopWorkspace` only initiates the stop transition; deleting immediately after races with the stopping process, leaving the workspace/task in a "paused" state
- Added `waitForWorkspaceStopped()` to `CoderClient` / `RealCoderClient` that polls every 2s until `latest_build.status` is `stopped`, `failed`, `canceled`, or `deleted` (120s timeout)
- `CloseTaskHandler` now waits for the workspace to stop before calling `deleteWorkspace`; if the wait times out it logs a warning and proceeds with best-effort deletion

## Test plan

- [x] `waitForWorkspaceStopped` resolves immediately when already stopped
- [x] `waitForWorkspaceStopped` resolves after workspace transitions to stopped
- [x] `waitForWorkspaceStopped` resolves on `failed` status
- [x] `waitForWorkspaceStopped` throws `CoderAPIError` on timeout
- [x] `CloseTaskHandler` calls `waitForWorkspaceStopped` between stop and delete
- [x] If `stopWorkspace` fails, `waitForWorkspaceStopped` is skipped
- [x] If `waitForWorkspaceStopped` times out, `deleteWorkspace` is still called
- [x] `bun run check` passes (89 tests, typecheck, lint, format)

Resolves https://github.com/xmtplabs/coder-action/issues/39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wait for workspace to reach a terminal state before deleting to prevent paused tasks
> - Adds `RealCoderClient.waitForWorkspaceStopped` in [coder-client.ts](https://github.com/xmtplabs/coder-action/pull/43/files#diff-04c65c8f5a37e5994d2afd0c78fe61a252a4f39142c7416f4ab15cc73d0e0107), which polls workspace status every 2s until it reaches a terminal state (`stopped`, `failed`, `canceled`, or `deleted`), throwing a 408 `CoderAPIError` on timeout (default 120s).
> - Updates `CloseTaskHandler.run` in [close-task.ts](https://github.com/xmtplabs/coder-action/pull/43/files#diff-1f73b02aa8d8b4334a84772e4ec6daca618a59e12563d4379cb99670ba16241c) to call `waitForWorkspaceStopped` after a successful stop, swallowing timeout errors with a warning before proceeding to delete.
> - If `stopWorkspace` fails, the wait is skipped and deletion proceeds immediately.
> - Behavioral Change: workspace deletion now waits up to 120s after a successful stop, adding latency to the close-task flow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bacf841.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->