### PR TITLE
fix: resume paused tasks before waiting for active state

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26218,6 +26218,12 @@ class RealCoderClient {
     const response = await this.request(`/api/v2/workspaces/${encodeURIComponent(workspaceId)}`);
     return WorkspaceSchema.parse(response);
   }
+  async startWorkspace(workspaceId) {
+    await this.request(`/api/v2/workspaces/${encodeURIComponent(workspaceId)}/builds`, {
+      method: "POST",
+      body: JSON.stringify({ transition: "start" })
+    });
+  }
   async stopWorkspace(workspaceId) {
     await this.request(`/api/v2/workspaces/${encodeURIComponent(workspaceId)}/builds`, {
       method: "POST",
@@ -26459,6 +26465,10 @@ async function lookupAndEnsureActiveTask(coder, coderUsername, taskName) {
     return task;
   }
   info(`Task ${taskName} is ${task.status}, waiting for active state...`);
+  if (task.status === "paused") {
+    info(`Resuming paused task ${taskName}...`);
+    await coder.startWorkspace(task.workspace_id);
+  }
   await coder.waitForTaskActive(task.owner_id, task.id, debug);
   return task;
 }

--- a/src/coder-client.ts
+++ b/src/coder-client.ts
@@ -161,6 +161,7 @@ export interface CoderClient {
 		timeoutMs?: number,
 	): Promise<void>;
 	getWorkspace(workspaceId: string): Promise<Workspace>;
+	startWorkspace(workspaceId: string): Promise<void>;
 	stopWorkspace(workspaceId: string): Promise<void>;
 	waitForWorkspaceStopped(
 		workspaceId: string,
@@ -391,6 +392,19 @@ export class RealCoderClient implements CoderClient {
 			`/api/v2/workspaces/${encodeURIComponent(workspaceId)}`,
 		);
 		return WorkspaceSchema.parse(response);
+	}
+
+	/**
+	 * startWorkspace initiates a start transition for the given workspace (resumes a paused task).
+	 */
+	async startWorkspace(workspaceId: string): Promise<void> {
+		await this.request(
+			`/api/v2/workspaces/${encodeURIComponent(workspaceId)}/builds`,
+			{
+				method: "POST",
+				body: JSON.stringify({ transition: "start" }),
+			},
+		);
 	}
 
 	/**

--- a/src/handlers/issue-comment.test.ts
+++ b/src/handlers/issue-comment.test.ts
@@ -136,8 +136,8 @@ describe("IssueCommentHandler", () => {
 		expect(result.skipReason).toContain("task-not-found");
 	});
 
-	// Edge: restart stopped task
-	test("restarts stopped task before sending", async () => {
+	// Edge: restart stopped (paused) task
+	test("resumes paused task before sending", async () => {
 		coder.getTask.mockResolvedValue(mockStoppedTask as never);
 		const handler = new IssueCommentHandler(
 			coder,
@@ -148,6 +148,10 @@ describe("IssueCommentHandler", () => {
 		const result = await handler.run();
 
 		expect(result.skipped).toBe(false);
+		expect(coder.startWorkspace).toHaveBeenCalledTimes(1);
+		expect(coder.startWorkspace).toHaveBeenCalledWith(
+			mockStoppedTask.workspace_id,
+		);
 		expect(coder.waitForTaskActive).toHaveBeenCalledTimes(1);
 		expect(coder.sendTaskInput).toHaveBeenCalledTimes(1);
 	});

--- a/src/handlers/pr-comment.test.ts
+++ b/src/handlers/pr-comment.test.ts
@@ -162,8 +162,8 @@ describe("PRCommentHandler", () => {
 		expect(result.skipReason).toContain("task-not-found");
 	});
 
-	// AC #15: Restart stopped task
-	test("restarts stopped task before sending", async () => {
+	// AC #15: Restart stopped (paused) task
+	test("resumes paused task before sending", async () => {
 		coder.getTask.mockResolvedValue(mockStoppedTask as never);
 		const handler = new PRCommentHandler(
 			coder,
@@ -174,6 +174,10 @@ describe("PRCommentHandler", () => {
 		const result = await handler.run();
 
 		expect(result.skipped).toBe(false);
+		expect(coder.startWorkspace).toHaveBeenCalledTimes(1);
+		expect(coder.startWorkspace).toHaveBeenCalledWith(
+			mockStoppedTask.workspace_id,
+		);
 		expect(coder.waitForTaskActive).toHaveBeenCalledTimes(1);
 		expect(coder.sendTaskInput).toHaveBeenCalledTimes(1);
 	});

--- a/src/task-utils.test.ts
+++ b/src/task-utils.test.ts
@@ -70,17 +70,19 @@ describe("lookupAndEnsureActiveTask", () => {
 		expect(result).toBeNull();
 	});
 
-	test("waits for task to become active when stopped", async () => {
+	test("resumes paused task and waits for active state", async () => {
 		const mockCoder = {
 			getTask: mock(() =>
 				Promise.resolve({
 					id: "uuid",
 					owner_id: "owner-uuid",
+					workspace_id: "ws-uuid",
 					name: "gh-repo-42",
 					status: "paused",
 					current_state: null,
 				}),
 			),
+			startWorkspace: mock(() => Promise.resolve()),
 			waitForTaskActive: mock(() => Promise.resolve()),
 		};
 		const result = await lookupAndEnsureActiveTask(
@@ -89,6 +91,7 @@ describe("lookupAndEnsureActiveTask", () => {
 			"gh-repo-42",
 		);
 		expect(result).not.toBeNull();
+		expect(mockCoder.startWorkspace).toHaveBeenCalledWith("ws-uuid");
 		expect(mockCoder.waitForTaskActive).toHaveBeenCalledWith(
 			"owner-uuid",
 			"uuid",

--- a/src/task-utils.ts
+++ b/src/task-utils.ts
@@ -49,6 +49,10 @@ export async function lookupAndEnsureActiveTask(
 	// Use task.owner_id (UUID) as the owner identifier — Coder accepts both
 	// usernames and UUIDs for user-scoped API paths.
 	core.info(`Task ${taskName} is ${task.status}, waiting for active state...`);
+	if (task.status === "paused") {
+		core.info(`Resuming paused task ${taskName}...`);
+		await coder.startWorkspace(task.workspace_id);
+	}
 	await coder.waitForTaskActive(task.owner_id, task.id, core.debug);
 	return task;
 }

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -68,6 +68,7 @@ export class MockCoderClient implements CoderClient {
 			latest_build: { status: "running", transition: "start" },
 		}),
 	);
+	startWorkspace = mock(() => Promise.resolve());
 	stopWorkspace = mock(() => Promise.resolve());
 	waitForWorkspaceStopped = mock(() => Promise.resolve());
 	deleteWorkspace = mock(() => Promise.resolve());


### PR DESCRIPTION
## Summary

- When a comment arrives on an issue/PR and the associated task is `paused`, `lookupAndEnsureActiveTask` was calling `waitForTaskActive` without first resuming the workspace — causing it to poll indefinitely and time out
- Added `startWorkspace()` call (via `POST /api/v2/workspaces/{id}/builds` with `transition: start`) when `task.status === "paused"` before entering the wait loop
- Added `startWorkspace` method to `CoderClient` interface, `RealCoderClient`, and `MockCoderClient`
- Updated tests in `task-utils.test.ts`, `issue-comment.test.ts`, and `pr-comment.test.ts` to verify `startWorkspace` is called with the correct workspace ID

## Test plan

- [x] `bun test` — all 92 tests pass
- [x] `bun run check` — typecheck, lint, format, and tests all pass
- [x] `bun run build` — dist/index.js rebuilt

Resolves https://github.com/xmtplabs/coder-action/issues/50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resume paused tasks before waiting for active state in `lookupAndEnsureActiveTask`
> When `lookupAndEnsureActiveTask` encounters a task with status `'paused'`, it now calls `coder.startWorkspace(task.workspace_id)` before invoking `waitForTaskActive`. Previously, paused tasks would stall indefinitely waiting for active state without being resumed first.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73a142b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->