### PR TITLE
feat: improve comment reply prompt with non-actionable detection and clear demarcation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26608,28 +26608,40 @@ function formatPRCommentMessage(params) {
 Commenter: ${params.commenter}
 Timestamp: ${params.timestamp}
 
-Validate whether the comment is useful feedback to improve the quality of the task output.
+[INSTRUCTIONS]
+First, determine whether this comment requires action.
 
-For all valid suggestions in the comment, implement them, ensure the branch is still in a healthy state (all lint and tests continue to pass), then commit and push. Reply to the comment with a succinct and clear explanation of the changes you made.
+If the comment is automated and does not require code changes or a reply — for example: bot status updates, approvability checks, CI notifications, merge conflict warnings, or other non-human automated comments — react to the comment with a \uD83D\uDC4D emoji and take no further action.
+
+If the comment contains valid suggestions or feedback from a human reviewer, implement them, ensure the branch is still in a healthy state (all lint and tests continue to pass), then commit and push. Reply to the comment with a succinct and clear explanation of the changes you made.
 
 If you have questions or need clarification, ask them directly in the comment thread and wait for further feedback.
 
-If no changes are needed or the comment is invalid, reply to the comment with a succinct and clear explanation why no action was taken.
----
+If no changes are needed or the comment is invalid feedback, reply to the comment with a succinct and clear explanation why no action was taken.
+[END INSTRUCTIONS]
 
-${params.body}`;
+[COMMENT]
+${params.body}
+[END COMMENT]`;
 }
 function formatIssueCommentMessage(params) {
   return `New Comment on Issue: ${params.commentUrl}
 Commenter: ${params.commenter}
 Timestamp: ${params.timestamp}
 
-Review this comment on the issue you are working on. If it contains new requirements, clarifications, or feedback that affects your current work, adjust your approach accordingly.
+[INSTRUCTIONS]
+First, determine whether this comment requires action.
+
+If the comment is automated and does not contain actionable information — for example: bot status updates, CI notifications, task tracking comments, or other non-human automated comments — react to the comment with a \uD83D\uDC4D emoji and take no further action.
+
+If the comment contains new requirements, clarifications, or feedback that affects your current work, adjust your approach accordingly.
 
 If the comment asks a question, reply directly on the issue.
----
+[END INSTRUCTIONS]
 
-${params.body}`;
+[COMMENT]
+${params.body}
+[END COMMENT]`;
 }
 function formatFailedCheckMessage(params) {
   const capped = params.failedJobs.slice(0, MAX_FAILED_JOBS);

--- a/src/messages.test.ts
+++ b/src/messages.test.ts
@@ -20,6 +20,34 @@ describe("formatPRCommentMessage", () => {
 		expect(msg).toContain("Timestamp: 2026-03-17T12:00:00Z");
 		expect(msg).toContain("Please fix the typo on line 42");
 	});
+
+	test("separates instructions from comment body with delimiters", () => {
+		const msg = formatPRCommentMessage({
+			commentUrl: "https://github.com/org/repo/pull/1#comment-1",
+			commenter: "reviewer",
+			timestamp: "2026-03-17T12:00:00Z",
+			body: "Please fix the typo on line 42",
+		});
+		expect(msg).toContain("[INSTRUCTIONS]");
+		expect(msg).toContain("[END INSTRUCTIONS]");
+		expect(msg).toContain("[COMMENT]");
+		expect(msg).toContain("[END COMMENT]");
+		// Instructions must appear before comment body
+		const instrIdx = msg.indexOf("[INSTRUCTIONS]");
+		const commentIdx = msg.indexOf("[COMMENT]");
+		expect(instrIdx).toBeLessThan(commentIdx);
+	});
+
+	test("instructs agent to react with 👍 for automated non-actionable comments", () => {
+		const msg = formatPRCommentMessage({
+			commentUrl: "https://github.com/org/repo/pull/1#comment-1",
+			commenter: "bot",
+			timestamp: "2026-03-17T12:00:00Z",
+			body: "Approvability check passed",
+		});
+		expect(msg).toContain("👍");
+		expect(msg).toContain("automated");
+	});
 });
 
 describe("formatIssueCommentMessage", () => {
@@ -33,6 +61,34 @@ describe("formatIssueCommentMessage", () => {
 		expect(msg).toContain("New Comment on Issue:");
 		expect(msg).toContain("Commenter: author");
 		expect(msg).toContain("Actually, the requirement changed");
+	});
+
+	test("separates instructions from comment body with delimiters", () => {
+		const msg = formatIssueCommentMessage({
+			commentUrl: "https://github.com/org/repo/issues/42#comment-1",
+			commenter: "author",
+			timestamp: "2026-03-17T12:00:00Z",
+			body: "Actually, the requirement changed",
+		});
+		expect(msg).toContain("[INSTRUCTIONS]");
+		expect(msg).toContain("[END INSTRUCTIONS]");
+		expect(msg).toContain("[COMMENT]");
+		expect(msg).toContain("[END COMMENT]");
+		// Instructions must appear before comment body
+		const instrIdx = msg.indexOf("[INSTRUCTIONS]");
+		const commentIdx = msg.indexOf("[COMMENT]");
+		expect(instrIdx).toBeLessThan(commentIdx);
+	});
+
+	test("instructs agent to react with 👍 for automated non-actionable comments", () => {
+		const msg = formatIssueCommentMessage({
+			commentUrl: "https://github.com/org/repo/issues/42#comment-1",
+			commenter: "github-actions",
+			timestamp: "2026-03-17T12:00:00Z",
+			body: "Task created: https://coder.example.com/tasks/123",
+		});
+		expect(msg).toContain("👍");
+		expect(msg).toContain("automated");
 	});
 });
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -20,16 +20,21 @@ export function formatPRCommentMessage(params: CommentMessageParams): string {
 Commenter: ${params.commenter}
 Timestamp: ${params.timestamp}
 
-Validate whether the comment is useful feedback to improve the quality of the task output.
+[INSTRUCTIONS]
+First, determine whether this comment requires action.
 
-For all valid suggestions in the comment, implement them, ensure the branch is still in a healthy state (all lint and tests continue to pass), then commit and push. Reply to the comment with a succinct and clear explanation of the changes you made.
+If the comment is automated and does not require code changes or a reply — for example: bot status updates, approvability checks, CI notifications, merge conflict warnings, or other non-human automated comments — react to the comment with a 👍 emoji and take no further action.
+
+If the comment contains valid suggestions or feedback from a human reviewer, implement them, ensure the branch is still in a healthy state (all lint and tests continue to pass), then commit and push. Reply to the comment with a succinct and clear explanation of the changes you made.
 
 If you have questions or need clarification, ask them directly in the comment thread and wait for further feedback.
 
-If no changes are needed or the comment is invalid, reply to the comment with a succinct and clear explanation why no action was taken.
----
+If no changes are needed or the comment is invalid feedback, reply to the comment with a succinct and clear explanation why no action was taken.
+[END INSTRUCTIONS]
 
-${params.body}`;
+[COMMENT]
+${params.body}
+[END COMMENT]`;
 }
 
 export function formatIssueCommentMessage(
@@ -39,12 +44,19 @@ export function formatIssueCommentMessage(
 Commenter: ${params.commenter}
 Timestamp: ${params.timestamp}
 
-Review this comment on the issue you are working on. If it contains new requirements, clarifications, or feedback that affects your current work, adjust your approach accordingly.
+[INSTRUCTIONS]
+First, determine whether this comment requires action.
+
+If the comment is automated and does not contain actionable information — for example: bot status updates, CI notifications, task tracking comments, or other non-human automated comments — react to the comment with a 👍 emoji and take no further action.
+
+If the comment contains new requirements, clarifications, or feedback that affects your current work, adjust your approach accordingly.
 
 If the comment asks a question, reply directly on the issue.
----
+[END INSTRUCTIONS]
 
-${params.body}`;
+[COMMENT]
+${params.body}
+[END COMMENT]`;
 }
 
 export function formatFailedCheckMessage(params: FailedCheckParams): string {


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/52

## Summary

- Add `[INSTRUCTIONS]` / `[END INSTRUCTIONS]` and `[COMMENT]` / `[END COMMENT]` delimiters to both `formatPRCommentMessage` and `formatIssueCommentMessage` so the LLM clearly distinguishes system directives from user-provided comment content.
- Instruct the agent to react with a 👍 emoji and take no further action when a comment is automated and non-actionable (e.g. bot status updates, approvability checks, CI notifications, merge conflict warnings).
- Add tests in `messages.test.ts` verifying delimiter structure and 👍 guidance for both PR and issue comment message formatters.

## Test plan

- [ ] `bun run check` passes (typecheck + lint + format + 96 tests)
- [ ] New tests verify `[INSTRUCTIONS]`/`[COMMENT]` delimiters appear in correct order
- [ ] New tests verify 👍 and "automated" keywords appear in both message types
- [ ] Existing handler tests still pass (message content assertions still satisfied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add non-actionable comment detection and structured delimiters to comment reply prompts
> - Rewrites the template strings in `formatPRCommentMessage` and `formatIssueCommentMessage` in [src/messages.ts](https://github.com/xmtplabs/coder-action/pull/53/files#diff-46bbb95b17ce5a3865ddffffb0fb655706c57eeb0b4a0d5fee7b2a4ed6564723) to wrap instructions in `[INSTRUCTIONS]...[END INSTRUCTIONS]` and the comment body in `[COMMENT]...[END COMMENT]` blocks.
> - Adds guidance for the agent to detect automated or non-actionable comments (e.g. bot comments) and react with a 👍 emoji instead of taking further action.
> - Adds tests in [src/messages.test.ts](https://github.com/xmtplabs/coder-action/pull/53/files#diff-891bf92ca588f221a23eb2d8c83f1ab6ba92978bc9e021d1672debe5c20d84ac) verifying the presence and ordering of delimiters and the 👍 emoji guidance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6617049.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->