### PR TITLE
fix: truncate long repo names to fit 32-char task name limit

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26448,8 +26448,16 @@ var ActionOutputsSchema = exports_external.object({
 });
 
 // src/task-utils.ts
+var MAX_TASK_NAME_LENGTH = 32;
 function generateTaskName(prefix, repo, issueNumber) {
-  return `${prefix}-${repo}-${issueNumber}`;
+  const issueStr = String(issueNumber);
+  const overhead = prefix.length + 1 + 1 + issueStr.length;
+  const maxRepoLength = MAX_TASK_NAME_LENGTH - overhead;
+  if (maxRepoLength <= 0) {
+    throw new Error(`Task name prefix "${prefix}" and issue number ${issueNumber} leave no room for the repo name (max ${MAX_TASK_NAME_LENGTH} chars)`);
+  }
+  const truncatedRepo = repo.length > maxRepoLength ? repo.slice(0, maxRepoLength).replace(/-+$/, "") : repo;
+  return `${prefix}-${truncatedRepo}-${issueStr}`;
 }
 async function lookupAndEnsureActiveTask(coder, coderUsername, taskName) {
   const parsedName = TaskNameSchema.parse(taskName);

--- a/src/task-utils.test.ts
+++ b/src/task-utils.test.ts
@@ -14,6 +14,32 @@ describe("generateTaskName", () => {
 	test("handles custom prefix", () => {
 		expect(generateTaskName("coder", "myrepo", 1)).toBe("coder-myrepo-1");
 	});
+
+	test("truncates long repo names to fit 32-char limit", () => {
+		const name = generateTaskName("gh", "a-very-long-repository-name-here", 42);
+		expect(name.length).toBeLessThanOrEqual(32);
+		expect(name).toBe("gh-a-very-long-repository-nam-42");
+	});
+
+	test("truncates repo with 5-digit issue number", () => {
+		const name = generateTaskName(
+			"gh",
+			"a-very-long-repository-name-here",
+			99999,
+		);
+		expect(name.length).toBeLessThanOrEqual(32);
+		expect(name).toBe("gh-a-very-long-repository-99999");
+	});
+
+	test("does not truncate short repo names", () => {
+		expect(generateTaskName("gh", "short", 1)).toBe("gh-short-1");
+	});
+
+	test("throws when prefix and issue number leave no room for repo", () => {
+		expect(() =>
+			generateTaskName("a-very-long-prefix-that-is-huge", "repo", 12345),
+		).toThrow("leave no room for the repo name");
+	});
 });
 
 describe("parseIssueURL", () => {

--- a/src/task-utils.ts
+++ b/src/task-utils.ts
@@ -2,12 +2,28 @@ import * as core from "@actions/core";
 import type { CoderClient, ExperimentalCoderSDKTask } from "./coder-client";
 import { TaskNameSchema } from "./coder-client";
 
+const MAX_TASK_NAME_LENGTH = 32;
+
 export function generateTaskName(
 	prefix: string,
 	repo: string,
 	issueNumber: number,
 ): string {
-	return `${prefix}-${repo}-${issueNumber}`;
+	const issueStr = String(issueNumber);
+	// Format: {prefix}-{repo}-{issueNumber}
+	// Coder API enforces a 32-character limit on task names.
+	const overhead = prefix.length + 1 + 1 + issueStr.length; // prefix + "-" + "-" + issueNumber
+	const maxRepoLength = MAX_TASK_NAME_LENGTH - overhead;
+	if (maxRepoLength <= 0) {
+		throw new Error(
+			`Task name prefix "${prefix}" and issue number ${issueNumber} leave no room for the repo name (max ${MAX_TASK_NAME_LENGTH} chars)`,
+		);
+	}
+	const truncatedRepo =
+		repo.length > maxRepoLength
+			? repo.slice(0, maxRepoLength).replace(/-+$/, "")
+			: repo;
+	return `${prefix}-${truncatedRepo}-${issueStr}`;
 }
 
 export function parseIssueURL(url: string): {


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/54

## Summary
- Truncates the repo portion of task names in `generateTaskName()` so the full name (`{prefix}-{repo}-{issueNumber}`) never exceeds the Coder API's 32-character limit
- Strips trailing dashes from truncated repo names to avoid ugly double-dash separators
- Throws a clear error if the prefix + issue number alone exceed the limit

## Test plan
- [x] Added test: long repo name is truncated to fit 32-char limit
- [x] Added test: truncation with 5-digit issue number
- [x] Added test: short repo names are not truncated
- [x] Added test: throws when prefix + issue number leave no room
- [x] All 100 existing tests pass
- [x] `bun run check` passes (typecheck + lint + format + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Truncate long repo names in `generateTaskName` to fit 32-character task name limit
> `generateTaskName` in [src/task-utils.ts](https://github.com/xmtplabs/coder-action/pull/55/files#diff-1bc5742e51aee1997494b10b73916480878736626d1f770fe69cb386e9b0e674) now enforces a `MAX_TASK_NAME_LENGTH` of 32 by truncating the repo segment to fit within the limit, stripping any trailing dashes from the truncated value. It throws an error when the prefix and issue number alone exceed 32 characters, leaving no room for the repo name.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2c84f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->