### PR TITLE
fix: update README permissions to pull-requests: write

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ on:
 permissions:
   actions: read
   issues: write
-  pull-requests: read
+  pull-requests: write
   contents: read
 
 jobs:


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/56

## Summary

- The README example workflow documented `pull-requests: read` but adding reactions to PR comments requires `pull-requests: write`
- Users copying the README example got "Resource not accessible by integration" errors when the action tried to add eye reactions to PR comments
- The `examples/workflows/coder.yml` already had the correct `pull-requests: write` permission — this fix aligns the README to match

## Test plan

- [x] All 100 existing tests pass
- [x] Verified the `examples/workflows/coder.yml` already uses `pull-requests: write`
- [ ] Deploy to a repo and confirm PR comment reactions work with the corrected permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `pull-requests` permission in README example from `read` to `write`
> Corrects the permissions YAML block in [README.md](https://github.com/xmtplabs/coder-action/pull/57/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) where `pull-requests: read` was listed but `write` is required for the action to function correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bcb4502.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->