### PR TITLE
fix: add pull_request_review event support for review submissions

### DIFF
--- a/.github/workflows/coder.yml
+++ b/.github/workflows/coder.yml
@@ -7,6 +7,8 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
   workflow_run:
     workflows: ["CI"]  # Change this to match your CI workflow names
     types: [completed]
@@ -73,6 +75,23 @@ jobs:
       && github.event.comment.user.login != 'xmtp-coder-agent'
     steps:
       - name: Forward PR Review Comment to Coder Task
+        uses: xmtplabs/coder-action@main
+        with:
+          action: pr_comment
+          coder-url: ${{ secrets.CODER_URL }}
+          coder-token: ${{ secrets.CODER_TOKEN }}
+          github-token: ${{ github.token }}
+
+  pr-review:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_review'
+      && github.event.action == 'submitted'
+      && github.event.pull_request.user.login == 'xmtp-coder-agent'
+      && github.event.review.user.login != 'xmtp-coder-agent'
+      && github.event.review.body != ''
+    steps:
+      - name: Forward PR Review to Coder Task
         uses: xmtplabs/coder-action@main
         with:
           action: pr_comment

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
   workflow_run:
     workflows: ["CI"]  # Change this to match your CI workflow names
     types: [completed]
@@ -96,6 +98,22 @@ jobs:
       && github.event.comment.user.login != 'xmtp-coder-agent'
     steps:
       - name: Forward PR Review Comment to Coder Task
+        uses: xmtplabs/coder-action@main
+        with:
+          action: pr_comment
+          coder-url: ${{ secrets.CODER_URL }}
+          coder-token: ${{ secrets.CODER_TOKEN }}
+
+  pr-review:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_review'
+      && github.event.action == 'submitted'
+      && github.event.pull_request.user.login == 'xmtp-coder-agent'
+      && github.event.review.user.login != 'xmtp-coder-agent'
+      && github.event.review.body != ''
+    steps:
+      - name: Forward PR Review to Coder Task
         uses: xmtplabs/coder-action@main
         with:
           action: pr_comment

--- a/dist/index.js
+++ b/dist/index.js
@@ -26692,6 +26692,10 @@ class PRCommentHandler {
       info("Ignoring self-comment from coder agent");
       return { skipped: true, skipReason: "self-comment" };
     }
+    if (this.context.isReviewSubmission && !this.context.commentBody?.trim()) {
+      info("Ignoring review submission with empty body");
+      return { skipped: true, skipReason: "empty-review-body" };
+    }
     const linkedIssues = await this.github.findLinkedIssues(this.context.owner, this.context.repo, this.context.prNumber);
     if (linkedIssues.length === 0) {
       info("No linked issue found");
@@ -26715,7 +26719,7 @@ class PRCommentHandler {
     });
     await this.coder.sendTaskInput(task.owner_id, task.id, message);
     info(`Comment forwarded to task ${taskName}`);
-    if (this.context.isReviewComment) {
+    if (this.context.isReviewSubmission) {} else if (this.context.isReviewComment) {
       await this.github.addReactionToReviewComment(this.context.owner, this.context.repo, this.context.commentId);
     } else {
       await this.github.addReactionToComment(this.context.owner, this.context.repo, this.context.commentId);
@@ -26892,19 +26896,21 @@ async function run() {
       }
       case "pr_comment": {
         const isReviewComment = context3.eventName === "pull_request_review_comment";
-        const pr = isReviewComment ? requirePayload(context3.payload.pull_request, "pull_request") : requirePayload(context3.payload.issue, "issue");
-        const comment = requirePayload(context3.payload.comment, "comment");
+        const isReviewSubmission = context3.eventName === "pull_request_review";
+        const pr = isReviewComment || isReviewSubmission ? requirePayload(context3.payload.pull_request, "pull_request") : requirePayload(context3.payload.issue, "issue");
+        const commentSource = isReviewSubmission ? requirePayload(context3.payload.review, "review") : requirePayload(context3.payload.comment, "comment");
         const handler2 = new PRCommentHandler(coder, gh, resolvedInputs, {
           owner: context3.repo.owner,
           repo: context3.repo.repo,
           prNumber: pr.number,
           prAuthor: pr.user.login,
-          commenterLogin: comment.user.login,
-          commentId: comment.id,
-          commentUrl: comment.html_url,
-          commentBody: comment.body,
-          commentCreatedAt: comment.created_at,
-          isReviewComment
+          commenterLogin: commentSource.user.login,
+          commentId: commentSource.id,
+          commentUrl: commentSource.html_url,
+          commentBody: isReviewSubmission ? commentSource.body ?? "" : commentSource.body,
+          commentCreatedAt: isReviewSubmission ? commentSource.submitted_at : commentSource.created_at,
+          isReviewComment,
+          isReviewSubmission
         });
         result = await handler2.run();
         break;

--- a/examples/workflows/coder.yml
+++ b/examples/workflows/coder.yml
@@ -7,6 +7,8 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
   workflow_run:
     # List the exact names of CI workflows to monitor.
     # These must match the `name:` field in each workflow file.
@@ -86,6 +88,25 @@ jobs:
       && github.event.comment.user.login != 'xmtp-coder-agent'
     steps:
       - name: Forward PR Review Comment to Coder Task
+        uses: xmtplabs/coder-action@v0
+        with:
+          action: pr_comment
+          coder-url: ${{ secrets.CODER_URL }}
+          coder-token: ${{ secrets.CODER_TOKEN }}
+          github-token: ${{ github.token }}
+
+  # ─── PR Review Forwarding ──────────────────────────────────────
+  # Triggered when someone submits a review (approve/request changes/comment) on a PR authored by the coder agent
+  pr-review:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_review'
+      && github.event.action == 'submitted'
+      && github.event.pull_request.user.login == 'xmtp-coder-agent'
+      && github.event.review.user.login != 'xmtp-coder-agent'
+      && github.event.review.body != ''
+    steps:
+      - name: Forward PR Review to Coder Task
         uses: xmtplabs/coder-action@v0
         with:
           action: pr_comment

--- a/src/handlers/pr-comment.test.ts
+++ b/src/handlers/pr-comment.test.ts
@@ -203,6 +203,80 @@ describe("PRCommentHandler", () => {
 		expect(String(taskNameArg)).toBe("gh-libxmtp-42");
 	});
 
+	// Issue #58: PR review submissions (approve/request changes/comment body)
+	describe("review submissions (isReviewSubmission: true)", () => {
+		const reviewSubmissionContext: PRCommentContext = {
+			...validContext,
+			commentUrl:
+				"https://github.com/xmtp/libxmtp/pull/5#pullrequestreview-123",
+			commentBody: "Please address the naming conventions",
+			isReviewSubmission: true,
+		};
+
+		test("forwards review submission body to task", async () => {
+			const handler = new PRCommentHandler(
+				coder,
+				github as unknown as import("../github-client").GitHubClient,
+				baseInputs,
+				reviewSubmissionContext,
+			);
+			const result = await handler.run();
+
+			expect(result.skipped).toBe(false);
+			expect(coder.sendTaskInput).toHaveBeenCalledTimes(1);
+			const sentMessage = (
+				coder.sendTaskInput.mock.calls[0] as unknown as [
+					string,
+					unknown,
+					string,
+				]
+			)[2];
+			expect(sentMessage).toContain("Please address the naming conventions");
+		});
+
+		test("skips review submission with empty body", async () => {
+			const ctx = { ...reviewSubmissionContext, commentBody: "" };
+			const handler = new PRCommentHandler(
+				coder,
+				github as unknown as import("../github-client").GitHubClient,
+				baseInputs,
+				ctx,
+			);
+			const result = await handler.run();
+
+			expect(result.skipped).toBe(true);
+			expect(result.skipReason).toBe("empty-review-body");
+			expect(coder.sendTaskInput).not.toHaveBeenCalled();
+		});
+
+		test("skips review submission with whitespace-only body", async () => {
+			const ctx = { ...reviewSubmissionContext, commentBody: "   \n  " };
+			const handler = new PRCommentHandler(
+				coder,
+				github as unknown as import("../github-client").GitHubClient,
+				baseInputs,
+				ctx,
+			);
+			const result = await handler.run();
+
+			expect(result.skipped).toBe(true);
+			expect(result.skipReason).toBe("empty-review-body");
+		});
+
+		test("does not add reaction for review submissions", async () => {
+			const handler = new PRCommentHandler(
+				coder,
+				github as unknown as import("../github-client").GitHubClient,
+				baseInputs,
+				reviewSubmissionContext,
+			);
+			await handler.run();
+
+			expect(github.addReactionToComment).not.toHaveBeenCalled();
+			expect(github.addReactionToReviewComment).not.toHaveBeenCalled();
+		});
+	});
+
 	// Issue #46: PR review comments (inline code comments)
 	describe("review comments (isReviewComment: true)", () => {
 		const reviewContext: PRCommentContext = {

--- a/src/handlers/pr-comment.ts
+++ b/src/handlers/pr-comment.ts
@@ -16,6 +16,7 @@ export interface PRCommentContext {
 	commentBody: string;
 	commentCreatedAt: string;
 	isReviewComment?: boolean;
+	isReviewSubmission?: boolean;
 }
 
 export class PRCommentHandler {
@@ -39,6 +40,12 @@ export class PRCommentHandler {
 		if (this.context.commenterLogin === this.inputs.coderGithubUsername) {
 			core.info("Ignoring self-comment from coder agent");
 			return { skipped: true, skipReason: "self-comment" };
+		}
+
+		// Guard: empty review body (e.g. approval with no text)
+		if (this.context.isReviewSubmission && !this.context.commentBody?.trim()) {
+			core.info("Ignoring review submission with empty body");
+			return { skipped: true, skipReason: "empty-review-body" };
 		}
 
 		// Find linked issue
@@ -84,7 +91,9 @@ export class PRCommentHandler {
 		await this.coder.sendTaskInput(task.owner_id, task.id, message);
 		core.info(`Comment forwarded to task ${taskName}`);
 
-		if (this.context.isReviewComment) {
+		if (this.context.isReviewSubmission) {
+			// No reaction API for review submissions — skip silently
+		} else if (this.context.isReviewComment) {
 			await this.github.addReactionToReviewComment(
 				this.context.owner,
 				this.context.repo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,21 +99,34 @@ async function run(): Promise<void> {
 			case "pr_comment": {
 				const isReviewComment =
 					context.eventName === "pull_request_review_comment";
-				const pr = isReviewComment
-					? requirePayload(context.payload.pull_request, "pull_request")
-					: requirePayload(context.payload.issue, "issue");
-				const comment = requirePayload(context.payload.comment, "comment");
+				const isReviewSubmission = context.eventName === "pull_request_review";
+
+				const pr =
+					isReviewComment || isReviewSubmission
+						? requirePayload(context.payload.pull_request, "pull_request")
+						: requirePayload(context.payload.issue, "issue");
+
+				// For review submissions, the comment data lives in payload.review
+				const commentSource = isReviewSubmission
+					? requirePayload(context.payload.review, "review")
+					: requirePayload(context.payload.comment, "comment");
+
 				const handler = new PRCommentHandler(coder, gh, resolvedInputs, {
 					owner: context.repo.owner,
 					repo: context.repo.repo,
 					prNumber: pr.number,
 					prAuthor: pr.user.login,
-					commenterLogin: comment.user.login,
-					commentId: comment.id,
-					commentUrl: comment.html_url,
-					commentBody: comment.body,
-					commentCreatedAt: comment.created_at,
+					commenterLogin: commentSource.user.login,
+					commentId: commentSource.id,
+					commentUrl: commentSource.html_url,
+					commentBody: isReviewSubmission
+						? (commentSource.body ?? "")
+						: commentSource.body,
+					commentCreatedAt: isReviewSubmission
+						? commentSource.submitted_at
+						: commentSource.created_at,
 					isReviewComment,
+					isReviewSubmission,
 				});
 				result = await handler.run();
 				break;


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/58

## Summary

- Added `pull_request_review` (submitted) event handling so that review submissions (approve/request changes/comment with body text) are forwarded to the agent
- Updated all three workflow files (`.github/workflows/coder.yml`, `README.md`, `examples/workflows/coder.yml`) with the new `pr-review` job and consistent trigger conditions
- Extended `PRCommentHandler` to handle review submissions: skips empty review bodies, skips reaction (no GitHub API for review reactions)
- Updated `src/index.ts` routing to extract review data from `payload.review` instead of `payload.comment`
- Added tests for review submission forwarding, empty body skipping, and reaction skipping

## What was missing

PR comments were handled via two events:
1. `issue_comment` — regular conversation comments
2. `pull_request_review_comment` — inline code review comments

But `pull_request_review` (submitted) — the review body when someone approves, requests changes, or leaves a comment review — was not captured. This meant review-level feedback was silently dropped.

## Test plan

- [x] All 104 existing tests pass
- [x] New tests cover: review submission forwarding, empty body skip, whitespace-only body skip, no reaction for review submissions
- [x] `bun run check` passes (typecheck + lint + format + test)
- [x] `dist/index.js` rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `pull_request_review` event support to forward review submissions to Coder tasks
> - Adds `pull_request_review: [submitted]` trigger to workflow files and a new `pr-review` job that forwards submitted reviews on coder-authored PRs to the Coder task via `pr_comment` action.
> - Updates `PRCommentHandler` in [pr-comment.ts](https://github.com/xmtplabs/coder-action/pull/59/files#diff-c83d00d43d7329b5f07264e70a2cfb7d14ba5c08730b5371a5a9b171cb54227d) to accept an `isReviewSubmission` flag, skip forwarding when the review body is empty or whitespace-only, and suppress reactions for review submissions.
> - Updates [src/index.ts](https://github.com/xmtplabs/coder-action/pull/59/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) to detect `pull_request_review` events, extract the review payload and `submitted_at` timestamp, and pass `isReviewSubmission` to the handler.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5840189.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->