### PR TITLE
fix: use task.owner_id for deleteTask in close_task handler

### DIFF
--- a/src/coder-client.ts
+++ b/src/coder-client.ts
@@ -169,7 +169,7 @@ export interface CoderClient {
 		timeoutMs?: number,
 	): Promise<void>;
 	deleteWorkspace(workspaceId: string): Promise<void>;
-	deleteTask(owner: string | undefined, taskId: TaskId): Promise<void>;
+	deleteTask(owner: string, taskId: TaskId): Promise<void>;
 }
 
 const POLL_INTERVAL_MS = 2000;
@@ -470,10 +470,7 @@ export class RealCoderClient implements CoderClient {
 	/**
 	 * deleteTask deletes a task via Coder's experimental Tasks API.
 	 */
-	async deleteTask(owner: string | undefined, taskId: TaskId): Promise<void> {
-		if (!owner) {
-			throw new Error("Cannot delete task: owner username is unknown");
-		}
+	async deleteTask(owner: string, taskId: TaskId): Promise<void> {
 		await this.request(
 			`/api/experimental/tasks/${encodeURIComponent(owner)}/${encodeURIComponent(taskId)}`,
 			{ method: "DELETE" },

--- a/src/handlers/close-task.test.ts
+++ b/src/handlers/close-task.test.ts
@@ -61,7 +61,7 @@ describe("CloseTaskHandler", () => {
 		);
 		expect(coder.deleteWorkspace).toHaveBeenCalledWith("ws-1");
 		expect(coder.deleteTask).toHaveBeenCalledWith(
-			baseInputs.coderUsername,
+			mockTask.owner_id,
 			mockTask.id,
 		);
 		expect(github.commentOnIssue).toHaveBeenCalledWith(
@@ -113,7 +113,7 @@ describe("CloseTaskHandler", () => {
 		expect(coder.waitForWorkspaceStopped).not.toHaveBeenCalled();
 		expect(coder.deleteWorkspace).toHaveBeenCalledWith("ws-1");
 		expect(coder.deleteTask).toHaveBeenCalledWith(
-			baseInputs.coderUsername,
+			mockTask.owner_id,
 			mockTask.id,
 		);
 	});
@@ -140,7 +140,7 @@ describe("CloseTaskHandler", () => {
 		expect(result.skipped).toBe(false);
 		expect(coder.deleteWorkspace).toHaveBeenCalledWith("ws-1");
 		expect(coder.deleteTask).toHaveBeenCalledWith(
-			baseInputs.coderUsername,
+			mockTask.owner_id,
 			mockTask.id,
 		);
 	});
@@ -164,7 +164,34 @@ describe("CloseTaskHandler", () => {
 
 		expect(result.skipped).toBe(false);
 		expect(coder.deleteTask).toHaveBeenCalledWith(
-			baseInputs.coderUsername,
+			mockTask.owner_id,
+			mockTask.id,
+		);
+	});
+
+	// Regression: coderUsername is undefined in production for close_task (issue #70)
+	test("uses task.owner_id for deleteTask even when coderUsername is undefined", async () => {
+		const inputsWithoutUsername: HandlerConfig = {
+			...baseInputs,
+			coderUsername: undefined,
+		};
+		coder.getTask.mockResolvedValue({
+			...mockTask,
+			workspace_id: "ws-1",
+		} as never);
+
+		const handler = new CloseTaskHandler(
+			coder,
+			github as unknown as import("../github-client").GitHubClient,
+			inputsWithoutUsername,
+			closeContext,
+			logger,
+		);
+		const result = await handler.run();
+
+		expect(result.skipped).toBe(false);
+		expect(coder.deleteTask).toHaveBeenCalledWith(
+			mockTask.owner_id,
 			mockTask.id,
 		);
 	});

--- a/src/handlers/close-task.ts
+++ b/src/handlers/close-task.ts
@@ -73,7 +73,7 @@ export class CloseTaskHandler {
 
 		// Delete task — continue even if this fails
 		try {
-			await this.coder.deleteTask(this.inputs.coderUsername, task.id);
+			await this.coder.deleteTask(task.owner_id, task.id);
 		} catch (error: unknown) {
 			this.logger.warn(`Failed to delete task: ${error}`);
 		}


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/70

## Summary

- **Root cause**: `close_task` handler passed `this.inputs.coderUsername` to `deleteTask()`, but `coderUsername` is only resolved for `create_task` — it was `undefined` for all other handlers, causing `deleteTask` to always throw "Cannot delete task: owner username is unknown"
- **Fix**: Use `task.owner_id` from the already-fetched task object instead. The Coder API accepts both usernames and UUIDs for user-scoped paths (already used this way in `task-utils.ts` for `sendTaskInput` and `waitForTaskActive`)
- **Also**: Tightened `deleteTask` signature from `string | undefined` to `string` and removed the now-unnecessary guard

## Changes

- `src/handlers/close-task.ts`: Pass `task.owner_id` to `deleteTask()` instead of `this.inputs.coderUsername`
- `src/coder-client.ts`: Change `deleteTask` owner param from `string | undefined` to `string`, remove the undefined guard
- `src/handlers/close-task.test.ts`: Update expectations to use `mockTask.owner_id`, add regression test for undefined `coderUsername`

## Test plan

- [x] All 187 existing tests pass
- [x] New regression test: verifies `deleteTask` uses `task.owner_id` even when `coderUsername` is `undefined`
- [x] Typecheck, lint, and format all pass (`bun run check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `deleteTask` in `CloseTaskHandler` to use `task.owner_id` instead of `inputs.coderUsername`
> The `CloseTaskHandler.run` method was passing `inputs.coderUsername` as the owner when deleting a task, which could be undefined or incorrect. It now passes `task.owner_id` directly, decoupling task deletion from the action's input username. The `deleteTask` signature in `CoderClient` is updated to require a non-optional `owner: string`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a91db9f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->