### PR TITLE
feat: include file path and line number in PR review comments

### DIFF
--- a/src/handler-dispatcher.ts
+++ b/src/handler-dispatcher.ts
@@ -114,6 +114,8 @@ export class HandlerDispatcher {
 						commentCreatedAt: ctx.commentCreatedAt,
 						isReviewComment: ctx.isReviewComment,
 						isReviewSubmission: ctx.isReviewSubmission,
+						filePath: ctx.filePath,
+						lineNumber: ctx.lineNumber,
 					},
 					logger,
 				);

--- a/src/handlers/pr-comment.test.ts
+++ b/src/handlers/pr-comment.test.ts
@@ -329,6 +329,35 @@ describe("PRCommentHandler", () => {
 			expect(coder.sendTaskInput).toHaveBeenCalledTimes(1);
 		});
 
+		test("includes file path and line number in forwarded message", async () => {
+			const ctx: PRCommentContext = {
+				...validContext,
+				commentUrl:
+					"https://github.com/xmtp/libxmtp/pull/5/changes#r2962833476",
+				commentBody: "This variable name is unclear",
+				isReviewComment: true,
+				filePath: "src/handlers/pr-comment.ts",
+				lineNumber: 42,
+			};
+			const handler = new PRCommentHandler(
+				coder,
+				github as unknown as import("../github-client").GitHubClient,
+				baseInputs,
+				ctx,
+				logger,
+			);
+			await handler.run();
+
+			const sentMessage = (
+				coder.sendTaskInput.mock.calls[0] as unknown as [
+					string,
+					unknown,
+					string,
+				]
+			)[2];
+			expect(sentMessage).toContain("File: src/handlers/pr-comment.ts:42");
+		});
+
 		test("adds 👀 reaction via review comment endpoint", async () => {
 			const handler = new PRCommentHandler(
 				coder,

--- a/src/handlers/pr-comment.ts
+++ b/src/handlers/pr-comment.ts
@@ -21,6 +21,8 @@ export interface PRCommentContext {
 	commentCreatedAt: string;
 	isReviewComment?: boolean;
 	isReviewSubmission?: boolean;
+	filePath?: string;
+	lineNumber?: number;
 }
 
 export class PRCommentHandler {
@@ -93,6 +95,8 @@ export class PRCommentHandler {
 			commenter: this.context.commenterLogin,
 			timestamp: this.context.commentCreatedAt,
 			body: this.context.commentBody,
+			filePath: this.context.filePath,
+			lineNumber: this.context.lineNumber,
 		});
 		await sendInputWithRetry(this.coder, task, message, this.logger);
 		this.logger.info(`Comment forwarded to task ${taskName}`);

--- a/src/messages.test.ts
+++ b/src/messages.test.ts
@@ -48,6 +48,40 @@ describe("formatPRCommentMessage", () => {
 		expect(msg).toContain("👍");
 		expect(msg).toContain("automated");
 	});
+
+	test("includes file path and line number for review comments", () => {
+		const msg = formatPRCommentMessage({
+			commentUrl: "https://github.com/org/repo/pull/1#comment-1",
+			commenter: "reviewer",
+			timestamp: "2026-03-17T12:00:00Z",
+			body: "This variable name is unclear",
+			filePath: "src/handlers/pr-comment.ts",
+			lineNumber: 42,
+		});
+		expect(msg).toContain("File: src/handlers/pr-comment.ts:42");
+	});
+
+	test("includes file path without line number when line is undefined", () => {
+		const msg = formatPRCommentMessage({
+			commentUrl: "https://github.com/org/repo/pull/1#comment-1",
+			commenter: "reviewer",
+			timestamp: "2026-03-17T12:00:00Z",
+			body: "This variable name is unclear",
+			filePath: "src/handlers/pr-comment.ts",
+		});
+		expect(msg).toContain("File: src/handlers/pr-comment.ts");
+		expect(msg).not.toContain("File: src/handlers/pr-comment.ts:");
+	});
+
+	test("omits file line when filePath is not provided", () => {
+		const msg = formatPRCommentMessage({
+			commentUrl: "https://github.com/org/repo/pull/1#comment-1",
+			commenter: "reviewer",
+			timestamp: "2026-03-17T12:00:00Z",
+			body: "General comment",
+		});
+		expect(msg).not.toContain("File:");
+	});
 });
 
 describe("formatIssueCommentMessage", () => {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -5,6 +5,8 @@ interface CommentMessageParams {
 	commenter: string;
 	timestamp: string;
 	body: string;
+	filePath?: string;
+	lineNumber?: number;
 }
 
 interface FailedCheckParams {
@@ -16,9 +18,13 @@ interface FailedCheckParams {
 }
 
 export function formatPRCommentMessage(params: CommentMessageParams): string {
+	const locationLine =
+		params.filePath != null
+			? `\nFile: ${params.filePath}${params.lineNumber != null ? `:${params.lineNumber}` : ""}`
+			: "";
 	return `New Comment on PR: ${params.commentUrl}
 Commenter: ${params.commenter}
-Timestamp: ${params.timestamp}
+Timestamp: ${params.timestamp}${locationLine}
 
 [INSTRUCTIONS]
 First, determine whether this comment requires action.

--- a/src/webhook-router.test.ts
+++ b/src/webhook-router.test.ts
@@ -283,6 +283,8 @@ describe("WebhookRouter", () => {
 		expect(ctx.isReviewSubmission).toBe(false);
 		expect(ctx.repoName).toBe("coder-action");
 		expect(ctx.repoOwner).toBe("xmtplabs");
+		expect(ctx.filePath).toBe("dist/server.js");
+		expect(ctx.lineNumber).toBe(1);
 	});
 
 	test("pull_request_review_comment.edited, PR by agent, comment by human → dispatched as pr_comment", async () => {

--- a/src/webhook-router.ts
+++ b/src/webhook-router.ts
@@ -46,6 +46,8 @@ export type PRCommentContext = {
 	commenterLogin: string;
 	isReviewComment: boolean;
 	isReviewSubmission: boolean;
+	filePath?: string;
+	lineNumber?: number;
 };
 
 export type IssueCommentContext = {
@@ -363,6 +365,8 @@ export class WebhookRouter {
 				commenterLogin: commentUserLogin,
 				isReviewComment: true,
 				isReviewSubmission: false,
+				filePath: payload.comment.path,
+				lineNumber: payload.comment.line ?? undefined,
 			},
 		};
 	}


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/81

## Summary

- Extracts `path` and `line` from `pull_request_review_comment` webhook payloads
- Adds a `File: <path>:<line>` line to the formatted message sent to Coder tasks
- Only appears for inline review comments (not general PR comments or review submissions)

## Changes

- `src/webhook-router.ts` — Extract `filePath` and `lineNumber` from review comment payloads
- `src/webhook-router.ts` — Add optional fields to `PRCommentContext` type
- `src/handler-dispatcher.ts` — Pass new fields through to handler
- `src/handlers/pr-comment.ts` — Add fields to interface and forward to message formatter
- `src/messages.ts` — Include `File:` line in output when file path is present

## Example output

```
New Comment on PR: https://github.com/org/repo/pull/1#comment-1
Commenter: reviewer
Timestamp: 2026-03-17T12:00:00Z
File: src/handlers/pr-comment.ts:42

[INSTRUCTIONS]
...
```

## Test plan

- [x] New test: `formatPRCommentMessage` includes file path and line number
- [x] New test: `formatPRCommentMessage` includes file path without line number
- [x] New test: `formatPRCommentMessage` omits file line when not provided
- [x] New test: PR comment handler includes file/line in forwarded review comment
- [x] New test: Webhook router extracts filePath and lineNumber from review comment fixture
- [x] All 187 tests pass, typecheck/lint/format clean

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include file path and line number in PR review comment messages
> - Extends `PRCommentContext` and `CommentMessageParams` with optional `filePath` and `lineNumber` fields, populated from the webhook payload's `comment.path` and `comment.line`.
> - `formatPRCommentMessage` now appends a `File: <path>[:<line>]` line to the formatted message when `filePath` is present.
> - The `WebhookRouter` extracts these fields from `pull_request_review_comment` events and passes them through to the handler via the dispatch context.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4a1bce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->