### PR TITLE
feat: increase waitForTaskActive timeout to 10 minutes

### DIFF
--- a/src/coder-client.ts
+++ b/src/coder-client.ts
@@ -354,7 +354,7 @@ export class RealCoderClient implements CoderClient {
 		owner: string,
 		taskId: TaskId,
 		logFn: (msg: string) => void,
-		timeoutMs = 120000,
+		timeoutMs = 600000,
 	): Promise<void> {
 		const startTime = Date.now();
 


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/83

## Summary

- Increases the default timeout for `waitForTaskActive` from 2 minutes (120s) to 10 minutes (600s) to accommodate tasks that take longer to wake from sleep.

## Changes

- `src/coder-client.ts`: Changed default `timeoutMs` parameter from `120000` to `600000` in `waitForTaskActive`.

## Test plan

- [x] All 187 existing tests pass
- [x] Typecheck, lint, and format checks pass