### PR TITLE
test: verify permission check uses assigner, not issue author

### DIFF
--- a/src/handler-dispatcher.test.ts
+++ b/src/handler-dispatcher.test.ts
@@ -113,6 +113,18 @@ describe("HandlerDispatcher", () => {
 			expect(coder.getCoderUserByGitHubId).toHaveBeenCalledWith(67890);
 		});
 
+		test("resolves coder user from sender (assigner), not issue author", async () => {
+			// senderId represents the person who assigned the bot, not the issue author
+			const ctx = {
+				...createTaskContext,
+				senderLogin: "org-maintainer",
+				senderId: 99999,
+			};
+			const result = makeDispatchedResult("create_task", ctx);
+			await dispatcher.dispatch(result);
+			expect(coder.getCoderUserByGitHubId).toHaveBeenCalledWith(99999);
+		});
+
 		test("creates a task and returns ActionOutputs", async () => {
 			coder.getTask.mockResolvedValue(null);
 			coder.createTask.mockResolvedValue(mockTask);

--- a/src/handlers/create-task.test.ts
+++ b/src/handlers/create-task.test.ts
@@ -80,6 +80,63 @@ describe("CreateTaskHandler", () => {
 		expect(coder.createTask).not.toHaveBeenCalled();
 	});
 
+	// Permission check must use the sender (assigner), not the issue author.
+	// This covers the case where an external user without write access creates
+	// the issue and a maintainer with write access assigns the bot.
+	test("checks permission for senderLogin (the assigner)", async () => {
+		github.checkActorPermission.mockResolvedValue(true);
+		coder.getTask.mockResolvedValue(null);
+		coder.createTask.mockResolvedValue(mockTask);
+
+		const ctx = {
+			...issueContext,
+			senderLogin: "maintainer-who-assigned",
+		};
+		const handler = new CreateTaskHandler(
+			coder,
+			github as unknown as import("../github-client").GitHubClient,
+			baseInputs,
+			ctx,
+			logger,
+		);
+		await handler.run();
+
+		expect(github.checkActorPermission).toHaveBeenCalledWith(
+			ctx.owner,
+			ctx.repo,
+			"maintainer-who-assigned",
+		);
+	});
+
+	test("creates task when assigner has write access regardless of issue author", async () => {
+		github.checkActorPermission.mockResolvedValue(true);
+		coder.getTask.mockResolvedValue(null);
+		coder.createTask.mockResolvedValue(mockTask);
+
+		// senderLogin is the maintainer who assigned the bot, not the issue author
+		const ctx = {
+			...issueContext,
+			senderLogin: "org-maintainer",
+		};
+		const handler = new CreateTaskHandler(
+			coder,
+			github as unknown as import("../github-client").GitHubClient,
+			baseInputs,
+			ctx,
+			logger,
+		);
+		const result = await handler.run();
+
+		expect(result.skipped).toBe(false);
+		expect(coder.createTask).toHaveBeenCalledTimes(1);
+		// Verify permission was checked for the assigner, not anyone else
+		expect(github.checkActorPermission).toHaveBeenCalledWith(
+			"xmtp",
+			"libxmtp",
+			"org-maintainer",
+		);
+	});
+
 	// AC #4: Issue URL appended to prompt
 	test("appends issue URL to prompt", async () => {
 		github.checkActorPermission.mockResolvedValue(true);

--- a/src/webhook-router.test.ts
+++ b/src/webhook-router.test.ts
@@ -75,6 +75,29 @@ describe("WebhookRouter", () => {
 		expect(ctx.senderId).toBe(65710);
 	});
 
+	test("issues.assigned extracts senderLogin from sender, not issue author", async () => {
+		// Simulate: external user created the issue, maintainer assigned the bot
+		const payload = {
+			...issuesAssigned,
+			issue: {
+				...issuesAssigned.issue,
+				user: { login: "external-user", id: 11111 },
+			},
+			sender: { login: "org-maintainer", id: 22222 },
+		};
+		const result = await router.handleWebhook(
+			"issues",
+			"delivery-001b",
+			payload,
+		);
+
+		expect(result.dispatched).toBe(true);
+		if (!result.dispatched) throw new Error("expected dispatched");
+		const ctx = result.context as CreateTaskContext;
+		expect(ctx.senderLogin).toBe("org-maintainer");
+		expect(ctx.senderId).toBe(22222);
+	});
+
 	test("issues.assigned with non-matching assignee login → skipped", async () => {
 		const payload = {
 			...issuesAssigned,


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/91

## Summary

The permission check for task creation already correctly uses the **sender** (the person who assigned the bot) rather than the issue author. This PR adds explicit test coverage for that behavior across three test files:

- **`create-task.test.ts`**: Verifies `checkActorPermission` is called with `senderLogin` (the assigner), and that tasks are created successfully when the assigner has write access regardless of who authored the issue.
- **`webhook-router.test.ts`**: Verifies the router extracts `senderLogin`/`senderId` from `payload.sender`, not `payload.issue.user`, when the two differ.
- **`handler-dispatcher.test.ts`**: Verifies Coder user resolution uses the sender's GitHub ID, not the issue author's.

## Test plan

- [x] All 195 tests pass
- [x] `bun run check` (typecheck + lint + format + tests) passes
- [x] New tests explicitly cover the scenario where an external user creates an issue and a maintainer assigns the bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests to verify permission checks use the assigner's identity, not the issue author
> - Adds a test in [handler-dispatcher.test.ts](https://github.com/xmtplabs/coder-action/pull/92/files#diff-140b7280019e3b5c266a8838f955d7875b6ef4f92d8d0cedf4ec15b5bb9d6c89) asserting `getCoderUserByGitHubId` is called with `senderId` (the assigner) when dispatching `create_task`.
> - Adds tests in [create-task.test.ts](https://github.com/xmtplabs/coder-action/pull/92/files#diff-cca9d7828b7215132205d9c34fc6f9b3598e7a0775437db860aac81f51e01470) asserting `checkActorPermission` uses `senderLogin` and that task creation proceeds based on assigner write access regardless of issue author.
> - Adds a test in [webhook-router.test.ts](https://github.com/xmtplabs/coder-action/pull/92/files#diff-e166e9dc694be06d411c81de3c82db78c9c5b34fd316e654ba188b4f18d156f1) asserting `senderLogin` and `senderId` are derived from the webhook `sender`, not `issue.user`, for `issues.assigned` events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2e4e57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->