### PR TITLE
Align project identity to task-action

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "coder-action",
+	"name": "task-action",
 	"image": "mcr.microsoft.com/devcontainers/typescript-node:24",
 	"features": {
 		"ghcr.io/devcontainers/features/github-cli:1": {}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — coder-action
+# AGENTS.md — task-action
 
 Cloudflare Worker + single Cloudflare Workflow that drives Coder AI task lifecycle from GitHub webhooks. The Worker signature-verifies and classifies each webhook, then enqueues a `CoderTaskWorkflow` instance that talks to the Coder and GitHub APIs durably (step-level retries, replay across isolate evictions).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "xmtp-coder-action",
+	"name": "xmtp-task-action",
 	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "xmtp-coder-action",
+			"name": "xmtp-task-action",
 			"version": "0.1.0",
 			"dependencies": {
 				"@octokit/auth-app": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "xmtp-coder-action",
+	"name": "xmtp-task-action",
 	"version": "0.1.0",
 	"description": "GitHub App webhook server for managing Coder AI task lifecycle",
 	"type": "module",


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/102

## Summary

The wrangler.toml worker name was already changed to `task-action` in PR #101. This follow-up aligns the remaining project identity references so the "action name" is consistently `task-action` everywhere it denotes the project (not the GitHub repo slug).

## Changes

- `package.json` / `package-lock.json`: `xmtp-coder-action` → `xmtp-task-action`
- `.devcontainer/devcontainer.json`: `coder-action` → `task-action`
- `AGENTS.md` header: `coder-action` → `task-action`

## Intentionally unchanged

- GitHub webhook fixture payloads under `src/testing/fixtures/` — these are snapshots of real events from the `xmtplabs/coder-action` repo and must match the actual repo name.
- Tests that assert `event.repository.name === "coder-action"` (e.g. `router.test.ts`, `payload-types.test.ts`) — same reason; repo name on GitHub is still `coder-action`.
- `README.md` heading `# xmtplabs/coder-action` — this is the GitHub repo slug.

## Test plan

- [x] `npm run check` (typecheck + lint + format:check + 246 tests) passes locally

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename project identity from `coder-action` to `task-action`
> Updates the project name across [package.json](https://github.com/xmtplabs/coder-action/pull/103/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), [AGENTS.md](https://github.com/xmtplabs/coder-action/pull/103/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9), and [devcontainer.json](https://github.com/xmtplabs/coder-action/pull/103/files#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686) to align with the new `task-action` identity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43c7788.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->