### PR TITLE
Rename webhook path, handler, and workflow to generic names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — task-action
 
-Cloudflare Worker + single Cloudflare Workflow that drives Coder AI task lifecycle from GitHub webhooks. The Worker signature-verifies and classifies each webhook, then enqueues a `CoderTaskWorkflow` instance that talks to the Coder and GitHub APIs durably (step-level retries, replay across isolate evictions).
+Cloudflare Worker + single Cloudflare Workflow that drives Coder AI task lifecycle from GitHub webhooks. The Worker signature-verifies and classifies each webhook, then enqueues a `TaskRunnerWorkflow` instance that talks to the Coder and GitHub APIs durably (step-level retries, replay across isolate evictions).
 
 **Tech stack:** Cloudflare Workers · Cloudflare Workflows · TypeScript (strict) · Zod · Biome · `@octokit/rest` · `@octokit/auth-app` · `@octokit/webhooks-methods` · `@cloudflare/vitest-pool-workers`
 
@@ -19,16 +19,16 @@ After changing `wrangler.toml`, regenerate binding types: `npx wrangler types`.
 ## Architecture
 
 ```
-GitHub  ───POST /api/webhooks───▶  Worker (src/main.ts)
+GitHub  ───POST /webhooks/github───▶  Worker (src/main.ts)
                                       │ parseWebhookRequest → verify sig + parse
                                       │   (401 bad sig · 400 missing header/JSON)
                                       │ WebhookRouter → classify + guards
                                       │   (200 skip for self-comments, workflow_run success, …)
                                       ▼
-                           env.CODER_TASK_WORKFLOW.create({ id, params })
+                           env.TASK_RUNNER_WORKFLOW.create({ id, params })
                                       │  202 Accepted
                                       ▼
-                       CoderTaskWorkflow (src/workflows/coder-task-workflow.ts)
+                       TaskRunnerWorkflow (src/workflows/task-runner-workflow.ts)
                                       │  dispatch on event.type
                                       ▼
                          src/workflows/steps/{create-task, close-task,
@@ -69,7 +69,7 @@ src/
     router.ts                         Event classification + guards → Event | SkipResult
     guards.ts                         Self-comment suppression, author checks, …
   workflows/
-    coder-task-workflow.ts            WorkflowEntrypoint — dispatches on event.type
+    task-runner-workflow.ts            WorkflowEntrypoint — dispatches on event.type
     instance-id.ts                    buildInstanceId + isDuplicateInstanceError
     ensure-task-ready.ts              step.sleep-based wait-for-idle loop
     steps/{create-task,close-task,comment,failed-check}.ts

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ A Cloudflare Worker that receives GitHub webhooks and drives the lifecycle of [C
 ## How It Works
 
 ```
-GitHub ──POST /api/webhooks──▶  Worker (fetch handler)
+GitHub ──POST /webhooks/github──▶  Worker (fetch handler)
                                   │  verify signature
                                   │  parse + route
                                   ▼
-                            CODER_TASK_WORKFLOW.create(…)
+                            TASK_RUNNER_WORKFLOW.create(…)
                                   │
                                   ▼
-                        CoderTaskWorkflow (durable)
+                        TaskRunnerWorkflow (durable)
                                   │  step.do / step.sleep
                                   ▼
                         Coder API  +  GitHub API

--- a/docs/adding-an-event-type.md
+++ b/docs/adding-an-event-type.md
@@ -26,11 +26,11 @@ Every field must be plain JSON-serializable (Workflow event payloads are structu
 
 ## 2. Webhook routing — `src/webhooks/github/router.ts`
 
-Add a `case` to the switch in `handleWebhook` that extracts the fields you need from the GitHub payload and returns the new `Event` variant (or a `SkipResult`). Follow the pattern of `routeIssuesAssigned` / `routePRReviewSubmitted` — cast the payload to the narrow `*Payload` type, run any applicable guards from `src/webhooks/github/guards.ts`, then return.
+Add a `case` to the switch in `handleGithubWebhook` that extracts the fields you need from the GitHub payload and returns the new `Event` variant (or a `SkipResult`). Follow the pattern of `routeIssuesAssigned` / `routePRReviewSubmitted` — cast the payload to the narrow `*Payload` type, run any applicable guards from `src/webhooks/github/guards.ts`, then return.
 
 If you need a new guard (e.g. "PR author is the agent"), add it to `guards.ts` and unit-test in `guards.test.ts`.
 
-## 3. Workflow dispatch — `src/workflows/coder-task-workflow.ts`
+## 3. Workflow dispatch — `src/workflows/task-runner-workflow.ts`
 
 Add a `case` to the `switch (payload.type)` in `run()` that calls a new step factory:
 
@@ -90,7 +90,7 @@ Three tests, in this order:
 
 ### Router test (`src/webhooks/github/router.test.ts`)
 
-Post a fixture payload through `router.handleWebhook` and assert the returned `Event` shape. Include self-comment / ignored-login / opt-out skip paths if applicable.
+Post a fixture payload through `router.handleGithubWebhook` and assert the returned `Event` shape. Include self-comment / ignored-login / opt-out skip paths if applicable.
 
 ### Step factory unit test (`src/workflows/steps/my-new-event.test.ts`)
 
@@ -104,11 +104,11 @@ Use the fake-`WorkflowStep` pattern (`makeStep()` in existing step tests). Asser
 
 See [testing.md § fake WorkflowStep](testing.md#fake-workflowstep-for-step-factory-unit-tests).
 
-### Workflow-level introspection test (`src/workflows/coder-task-workflow.test.ts`)
+### Workflow-level introspection test (`src/workflows/task-runner-workflow.test.ts`)
 
 Add a test in the appropriate `describe` block that:
 
-1. Acquires `introspectWorkflowInstance(env.CODER_TASK_WORKFLOW, id)` with `await using`.
+1. Acquires `introspectWorkflowInstance(env.TASK_RUNNER_WORKFLOW, id)` with `await using`.
 2. Calls `instance.modify(async (m) => { await m.disableSleeps(); await m.mockStepResult({ name: "..." }, ...); })` for every step your factory emits.
 3. Creates the instance with a representative `Event` payload.
 4. Asserts `waitForStatus("complete")`.

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -28,7 +28,7 @@ Both identities' comments are suppressed during webhook processing to prevent in
    |-------|-------|
    | **GitHub App name** | `xmtp-coder-app` (or your preferred name) |
    | **Homepage URL** | `https://github.com/your-org/coder-action` |
-   | **Webhook URL** | `https://your-server/api/webhooks` |
+   | **Webhook URL** | `https://your-server/webhooks/github` |
    | **Webhook secret** | A strong random string (save this — you will need it for `WEBHOOK_SECRET`) |
 
 3. Leave **"Expire user authorization tokens"** checked (default).

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -113,7 +113,7 @@ GitHub webhooks can be ~25 MB in extreme cases (huge commit lists, large diffs).
 
 ## Workflow binding rename orphans in-flight instances
 
-If you ever rename `CODER_TASK_WORKFLOW` in `wrangler.toml`, in-flight instances bound to the old name are orphaned. Use [`migrateWorkflowBinding()`](https://developers.cloudflare.com/agents/api-reference/run-workflows/) in a dedicated migration step — don't bundle with other changes. (We don't currently plan to rename; this is a footgun for the future.)
+If you ever rename `TASK_RUNNER_WORKFLOW` in `wrangler.toml`, in-flight instances bound to the old name are orphaned. Use [`migrateWorkflowBinding()`](https://developers.cloudflare.com/agents/api-reference/run-workflows/) in a dedicated migration step — don't bundle with other changes. (We don't currently plan to rename; this is a footgun for the future.)
 
 ## Uncaught errors in `run()` → `errored` state (intentional)
 
@@ -131,11 +131,11 @@ Workflow introspectors hold storage handles. Forgetting `await using` (or explic
 
 ```ts
 // ✅
-await using instance = await introspectWorkflowInstance(env.CODER_TASK_WORKFLOW, id);
+await using instance = await introspectWorkflowInstance(env.TASK_RUNNER_WORKFLOW, id);
 
 // ❌ state persists across tests; instance that completed in this test will
 // already be marked complete in the next
-const instance = await introspectWorkflowInstance(env.CODER_TASK_WORKFLOW, id);
+const instance = await introspectWorkflowInstance(env.TASK_RUNNER_WORKFLOW, id);
 ```
 
 See [testing.md](testing.md#workflow-introspection-pattern) for the full pattern.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,7 +13,7 @@ npm run test:watch   # hot reload
 |---|---|---|
 | **Unit** | Colocated `*.test.ts` next to source | Pure helpers, step factories with fake `step`, parsers, guards, routers. Fast. No workflow engine. |
 | **HTTP integration** | `src/testing/integration.test.ts` | Full worker fetch handler with the workflow binding stubbed. Exercises every HTTP status code path (200/202/400/401/404/500). |
-| **End-to-end** | `src/testing/e2e.test.ts` | Signed webhook → real `env.CODER_TASK_WORKFLOW` → introspected instance → `waitForStatus("complete")`. The only tests that drive a real workflow instance from the fetch handler. |
+| **End-to-end** | `src/testing/e2e.test.ts` | Signed webhook → real `env.TASK_RUNNER_WORKFLOW` → introspected instance → `waitForStatus("complete")`. The only tests that drive a real workflow instance from the fetch handler. |
 
 ## Workflow introspection pattern
 
@@ -25,7 +25,7 @@ import { env, introspectWorkflowInstance } from "cloudflare:test";
 test("task_requested runs to completion", async () => {
   // 1. Register the introspector BEFORE creating the instance.
   await using instance = await introspectWorkflowInstance(
-    env.CODER_TASK_WORKFLOW,
+    env.TASK_RUNNER_WORKFLOW,
     "my-instance-id",
   );
 
@@ -42,7 +42,7 @@ test("task_requested runs to completion", async () => {
   });
 
   // 3. Create the instance.
-  await env.CODER_TASK_WORKFLOW.create({ id: "my-instance-id", params: {...} });
+  await env.TASK_RUNNER_WORKFLOW.create({ id: "my-instance-id", params: {...} });
 
   // 4. Assert terminal status.
   await expect(instance.waitForStatus("complete")).resolves.not.toThrow();
@@ -55,7 +55,7 @@ test("task_requested runs to completion", async () => {
 
 **For void returns use `{}`, not `null` or `undefined`.** Miniflare treats falsy values as "no mock set" — see [gotchas.md](gotchas.md#mockstepresult-with-falsy-values-is-treated-as-no-mock-set).
 
-**For tests where instance IDs are unknown ahead of time** (e.g. the webhook handler creates them with a composite ID), use `introspectWorkflow(env.CODER_TASK_WORKFLOW)` instead and call `introspector.modifyAll(...)`. See `src/testing/e2e.test.ts`.
+**For tests where instance IDs are unknown ahead of time** (e.g. the webhook handler creates them with a composite ID), use `introspectWorkflow(env.TASK_RUNNER_WORKFLOW)` instead and call `introspector.modifyAll(...)`. See `src/testing/e2e.test.ts`.
 
 ## Fake `WorkflowStep` for step-factory unit tests
 
@@ -116,7 +116,7 @@ For tests with shared mock-client boilerplate (e.g. `comment.test.ts` has four r
 
 ## Integration vs. e2e env
 
-- Integration tests (`src/testing/integration.test.ts`) use a **stub** `env.CODER_TASK_WORKFLOW` — a plain object with a `create` method. This lets each test control the workflow-create outcome (resolve with id, reject with "already exists", reject with generic error) to exercise response-status paths.
+- Integration tests (`src/testing/integration.test.ts`) use a **stub** `env.TASK_RUNNER_WORKFLOW` — a plain object with a `create` method. This lets each test control the workflow-create outcome (resolve with id, reject with "already exists", reject with generic error) to exercise response-status paths.
 
 - E2E tests (`src/testing/e2e.test.ts`) use the **real** `env` from `cloudflare:test`, which includes the actual Workflow binding. Paired with `introspectWorkflow`, this drives the real workflow through to completion.
 

--- a/src/http/parse-webhook-request.test.ts
+++ b/src/http/parse-webhook-request.test.ts
@@ -25,7 +25,7 @@ async function signedReq(opts: {
 	};
 	if (opts.eventName) headers["X-GitHub-Event"] = opts.eventName;
 	if (opts.deliveryId) headers["X-GitHub-Delivery"] = opts.deliveryId;
-	return new Request("https://w/api/webhooks", {
+	return new Request("https://w/webhooks/github", {
 		method: "POST",
 		headers,
 		body: opts.body,
@@ -58,7 +58,7 @@ describe("parseWebhookRequest — happy path", () => {
 describe("parseWebhookRequest — typed errors", () => {
 	test("missing X-Hub-Signature-256 → MissingSignatureError (401)", async () => {
 		const body = "{}";
-		const req = new Request("https://w/api/webhooks", {
+		const req = new Request("https://w/webhooks/github", {
 			method: "POST",
 			headers: { "X-GitHub-Event": "issues" },
 			body,
@@ -139,7 +139,7 @@ describe("parseWebhookRequest — typed errors", () => {
 		// JSON stage (400). Proves the parser doesn't leak information about
 		// the body shape to unauthenticated callers.
 		const body = "not { json";
-		const req = new Request("https://w/api/webhooks", {
+		const req = new Request("https://w/webhooks/github", {
 			method: "POST",
 			headers: { "X-GitHub-Event": "issues" },
 			body,

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,13 +9,13 @@ import {
 } from "./http/parse-webhook-request";
 import { createLogger } from "./utils/logger";
 import { WebhookRouter } from "./webhooks/github/router";
-import type { CoderTaskWorkflowEnv } from "./workflows/coder-task-workflow";
+import type { TaskRunnerWorkflowEnv } from "./workflows/task-runner-workflow";
 import {
 	buildInstanceId,
 	isDuplicateInstanceError,
 } from "./workflows/instance-id";
 
-export { CoderTaskWorkflow } from "./workflows/coder-task-workflow";
+export { TaskRunnerWorkflow } from "./workflows/task-runner-workflow";
 export { __setAppBotLoginForTests };
 
 // ── Worker entrypoint ────────────────────────────────────────────────────────
@@ -23,22 +23,22 @@ export { __setAppBotLoginForTests };
 export default {
 	async fetch(
 		request: Request,
-		env: CoderTaskWorkflowEnv,
+		env: TaskRunnerWorkflowEnv,
 		_ctx: ExecutionContext,
 	): Promise<Response> {
 		const url = new URL(request.url);
 
-		if (request.method === "POST" && url.pathname === "/api/webhooks") {
-			return handleWebhook(request, env);
+		if (request.method === "POST" && url.pathname === "/webhooks/github") {
+			return handleGithubWebhook(request, env);
 		}
 
 		return new Response("Not Found", { status: 404 });
 	},
-} satisfies ExportedHandler<CoderTaskWorkflowEnv>;
+} satisfies ExportedHandler<TaskRunnerWorkflowEnv>;
 
-async function handleWebhook(
+async function handleGithubWebhook(
 	request: Request,
-	env: CoderTaskWorkflowEnv,
+	env: TaskRunnerWorkflowEnv,
 ): Promise<Response> {
 	const config = loadConfig(
 		env as unknown as Record<string, string | undefined>,
@@ -69,7 +69,11 @@ async function handleWebhook(
 		appBotLogin,
 		logger: reqLogger,
 	});
-	const result = await router.handleWebhook(eventName, deliveryId, payload);
+	const result = await router.handleGithubWebhook(
+		eventName,
+		deliveryId,
+		payload,
+	);
 	if ("dispatched" in result) {
 		const status = result.validationError === true ? 400 : 200;
 		reqLogger.info("Webhook skipped", {
@@ -83,7 +87,7 @@ async function handleWebhook(
 	// Stage 3: dispatch to Workflow (fire-and-return-202).
 	const instanceId = buildInstanceId(result, deliveryId);
 	try {
-		await env.CODER_TASK_WORKFLOW.create({ id: instanceId, params: result });
+		await env.TASK_RUNNER_WORKFLOW.create({ id: instanceId, params: result });
 		reqLogger.info("Webhook processed", {
 			handler: result.type,
 			instanceId,

--- a/src/testing/AGENTS.md
+++ b/src/testing/AGENTS.md
@@ -6,10 +6,10 @@ Shared test utilities + integration/e2e test suites.
 
 ```ts
 // ✅ await using disposes automatically at scope end
-await using introspector = await introspectWorkflow(env.CODER_TASK_WORKFLOW);
+await using introspector = await introspectWorkflow(env.TASK_RUNNER_WORKFLOW);
 
 // ✅ Explicit dispose also works
-const introspector = await introspectWorkflow(env.CODER_TASK_WORKFLOW);
+const introspector = await introspectWorkflow(env.TASK_RUNNER_WORKFLOW);
 try { /* ... */ } finally { await introspector.dispose(); }
 ```
 
@@ -21,8 +21,8 @@ Miniflare's `mockStepResult` treats falsy values as "no mock set" — the real c
 
 ## Integration vs. e2e tests
 
-- **`integration.test.ts`** — stubs `env.CODER_TASK_WORKFLOW` to assert HTTP status paths (200/202/400/401/404/500). Workflow never actually runs.
-- **`e2e.test.ts`** — uses the real `env.CODER_TASK_WORKFLOW` binding + `introspectWorkflow` to drive a full signed-webhook → completed-workflow pipeline. Exactly one test per event type; happy paths only.
+- **`integration.test.ts`** — stubs `env.TASK_RUNNER_WORKFLOW` to assert HTTP status paths (200/202/400/401/404/500). Workflow never actually runs.
+- **`e2e.test.ts`** — uses the real `env.TASK_RUNNER_WORKFLOW` binding + `introspectWorkflow` to drive a full signed-webhook → completed-workflow pipeline. Exactly one test per event type; happy paths only.
 
 Pick integration for status-code coverage, e2e for "does the full pipeline actually wire up."
 

--- a/src/testing/e2e.test.ts
+++ b/src/testing/e2e.test.ts
@@ -24,13 +24,13 @@ const testEnv = env as TestEnv;
 type WorkerEnv = Parameters<typeof worker.fetch>[1];
 
 /**
- * End-to-end signed-webhook → worker fetch handler → real env.CODER_TASK_WORKFLOW
+ * End-to-end signed-webhook → worker fetch handler → real env.TASK_RUNNER_WORKFLOW
  * → introspected workflow completion. Only test in the suite exercising the
  * full pipeline including:
  *
  *   • HMAC signature verification
  *   • WebhookRouter classification
- *   • `env.CODER_TASK_WORKFLOW.create({ id, params })` on the real binding
+ *   • `env.TASK_RUNNER_WORKFLOW.create({ id, params })` on the real binding
  *   • Workflow `run()` dispatch to the correct step factory
  *   • Introspection-driven step-result mocks
  *   • `waitForStatus("complete")` confirming the instance ran to completion
@@ -42,7 +42,7 @@ type WorkerEnv = Parameters<typeof worker.fetch>[1];
 describe("e2e: signed webhook → worker → workflow completion", () => {
 	test("task_requested webhook runs the full pipeline to instance completion", async () => {
 		await using introspector = await introspectWorkflow(
-			testEnv.CODER_TASK_WORKFLOW,
+			testEnv.TASK_RUNNER_WORKFLOW,
 		);
 		await introspector.modifyAll(async (m) => {
 			await m.disableSleeps();
@@ -86,7 +86,7 @@ describe("e2e: signed webhook → worker → workflow completion", () => {
 
 	test("task_closed webhook runs delete → comment to completion", async () => {
 		await using introspector = await introspectWorkflow(
-			testEnv.CODER_TASK_WORKFLOW,
+			testEnv.TASK_RUNNER_WORKFLOW,
 		);
 		await introspector.modifyAll(async (m) => {
 			await m.disableSleeps();

--- a/src/testing/integration.test.ts
+++ b/src/testing/integration.test.ts
@@ -15,7 +15,7 @@ beforeEach(() => {
 
 // ── Env fixture ──────────────────────────────────────────────────────────────
 //
-// Minimum env shape the Worker's `handleWebhook` expects. `CODER_TASK_WORKFLOW`
+// Minimum env shape the Worker's `handleGithubWebhook` expects. `TASK_RUNNER_WORKFLOW`
 // is stubbed so `.create()` can succeed without a real workflow binding — we
 // only assert the HTTP response status in these tests, not workflow behavior.
 // (End-to-end coverage with the real binding + `introspectWorkflow` lives in
@@ -51,7 +51,7 @@ function makeEnv(
 ) {
 	return {
 		...baseEnv,
-		CODER_TASK_WORKFLOW: {
+		TASK_RUNNER_WORKFLOW: {
 			create:
 				workflowCreate ??
 				((args: WorkflowCreateArgs) => Promise.resolve({ id: args.id })),
@@ -149,7 +149,7 @@ describe("Worker fetch handler — HTTP status surface", () => {
 		const body = JSON.stringify(issuesAssigned);
 		// Hand-build the request so we can omit the event-name header.
 		const signature = await computeSignature(TEST_SECRET, body);
-		const req = new Request("https://w/api/webhooks", {
+		const req = new Request("https://w/webhooks/github", {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
@@ -216,7 +216,7 @@ describe("Worker fetch handler — HTTP status surface", () => {
 			return Promise.resolve({ id: "x" });
 		});
 		const body = JSON.stringify(issuesAssigned);
-		const req = new Request("https://w/api/webhooks", {
+		const req = new Request("https://w/webhooks/github", {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
@@ -260,9 +260,9 @@ describe("Worker fetch handler — HTTP status surface", () => {
 		expect(res.status).toBe(404);
 	});
 
-	test("GET /api/webhooks → 404 (only POST is a route)", async () => {
+	test("GET /webhooks/github → 404 (only POST is a route)", async () => {
 		const res = await worker.fetch(
-			new Request("https://w/api/webhooks", { method: "GET" }),
+			new Request("https://w/webhooks/github", { method: "GET" }),
 			makeEnv(),
 			{} as ExecutionContext,
 		);

--- a/src/testing/workflow-test-helpers.ts
+++ b/src/testing/workflow-test-helpers.ts
@@ -41,7 +41,7 @@ export async function buildSignedWebhookRequest(
 ): Promise<Request> {
 	const signature =
 		opts.signature ?? (await computeSignature(opts.secret, opts.body));
-	return new Request("https://example.com/api/webhooks", {
+	return new Request("https://example.com/webhooks/github", {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",

--- a/src/webhooks/github/AGENTS.md
+++ b/src/webhooks/github/AGENTS.md
@@ -4,7 +4,7 @@ Converts raw GitHub webhook payloads into the app's `Event` discriminated union 
 
 ## Output is always `Event` or `SkipResult`
 
-`WebhookRouter.handleWebhook()` returns one of two shapes:
+`WebhookRouter.handleGithubWebhook()` returns one of two shapes:
 
 - **`Event`** — the webhook is actionable; Worker creates a Workflow instance.
 - **`SkipResult`** — deliberately not actionable (self-comment, non-assignee, success workflow_run, …). Worker returns 200 with no Workflow.

--- a/src/webhooks/github/router.test.ts
+++ b/src/webhooks/github/router.test.ts
@@ -60,7 +60,7 @@ describe("WebhookRouter", () => {
 	// ── issues.assigned ────────────────────────────────────────────────────────
 
 	test("issues.assigned with matching agent login → task_requested event", async () => {
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"issues",
 			"delivery-001",
 			issuesAssigned,
@@ -89,7 +89,7 @@ describe("WebhookRouter", () => {
 			...issuesAssigned,
 			assignee: { login: "other-user", id: 99 },
 		};
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"issues",
 			"delivery-002",
 			payload,
@@ -103,7 +103,7 @@ describe("WebhookRouter", () => {
 	// ── issues.closed ──────────────────────────────────────────────────────────
 
 	test("issues.closed → task_closed event", async () => {
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"issues",
 			"delivery-003",
 			issuesClosed,
@@ -131,7 +131,7 @@ describe("WebhookRouter", () => {
 				user: { login: APP_BOT_LOGIN },
 			},
 		};
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"issue_comment",
 			"delivery-004",
 			payload,
@@ -150,7 +150,7 @@ describe("WebhookRouter", () => {
 				user: { login: AGENT_USER_LOGIN },
 			},
 		};
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"issue_comment",
 			"delivery-005",
 			payload,
@@ -164,7 +164,7 @@ describe("WebhookRouter", () => {
 	// ── issue_comment.created — dispatch ──────────────────────────────────────
 
 	test("issue_comment.created on issue from human → comment_posted event (kind: issue)", async () => {
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"issue_comment",
 			"delivery-006",
 			issueCommentOnIssue,
@@ -199,7 +199,7 @@ describe("WebhookRouter", () => {
 				user: { login: "some-other-user" },
 			},
 		};
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"issue_comment",
 			"delivery-007a",
 			payload,
@@ -214,7 +214,7 @@ describe("WebhookRouter", () => {
 
 	test("issue_comment.edited on issue from human → comment_posted event (kind: issue)", async () => {
 		const payload = { ...issueCommentOnIssue, action: "edited" };
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"issue_comment",
 			"delivery-006a",
 			payload,
@@ -232,7 +232,7 @@ describe("WebhookRouter", () => {
 
 	test("issue_comment.edited on PR from human → comment_posted event (kind: pull_request)", async () => {
 		const payload = { ...issueCommentOnPr, action: "edited" };
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"issue_comment",
 			"delivery-006b",
 			payload,
@@ -253,7 +253,7 @@ describe("WebhookRouter", () => {
 			...issueCommentOnIssue,
 			action: "deleted",
 		};
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"issue_comment",
 			"delivery-006c",
 			payload,
@@ -266,7 +266,7 @@ describe("WebhookRouter", () => {
 	});
 
 	test("issue_comment.created on PR from human → comment_posted event (kind: pull_request)", async () => {
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"issue_comment",
 			"delivery-007",
 			issueCommentOnPr,
@@ -291,7 +291,7 @@ describe("WebhookRouter", () => {
 	// ── pull_request_review_comment.created ───────────────────────────────────
 
 	test("pull_request_review_comment.created, PR by agent, comment by human → comment_posted with isReviewComment", async () => {
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"pull_request_review_comment",
 			"delivery-008",
 			prReviewComment,
@@ -314,7 +314,7 @@ describe("WebhookRouter", () => {
 	});
 
 	test("pull_request_review_comment.created populates comment.filePath and comment.lineNumber from payload", async () => {
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"pull_request_review_comment",
 			"delivery-008b",
 			prReviewComment,
@@ -331,7 +331,7 @@ describe("WebhookRouter", () => {
 
 	test("pull_request_review_comment.edited, PR by agent, comment by human → comment_posted event", async () => {
 		const payload = { ...prReviewComment, action: "edited" };
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"pull_request_review_comment",
 			"delivery-008a",
 			payload,
@@ -352,7 +352,7 @@ describe("WebhookRouter", () => {
 			...prReviewComment,
 			comment: { ...prReviewComment.comment, user: { login: APP_BOT_LOGIN } },
 		};
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"pull_request_review_comment",
 			"delivery-009",
 			payload,
@@ -371,7 +371,7 @@ describe("WebhookRouter", () => {
 				user: { login: "other-user" },
 			},
 		};
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"pull_request_review_comment",
 			"delivery-010",
 			payload,
@@ -385,7 +385,7 @@ describe("WebhookRouter", () => {
 	// ── pull_request_review.submitted ─────────────────────────────────────────
 
 	test("pull_request_review.submitted with body, PR by agent, reviewer is human → comment_posted with isReviewSubmission", async () => {
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"pull_request_review",
 			"delivery-011",
 			prReviewSubmitted,
@@ -415,7 +415,7 @@ describe("WebhookRouter", () => {
 				user: { login: AGENT_USER_LOGIN },
 			},
 		};
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"pull_request_review",
 			"delivery-012",
 			payload,
@@ -427,7 +427,7 @@ describe("WebhookRouter", () => {
 	});
 
 	test("pull_request_review.submitted with empty body → skipped", async () => {
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"pull_request_review",
 			"delivery-013",
 			prReviewSubmittedEmpty,
@@ -441,7 +441,7 @@ describe("WebhookRouter", () => {
 	// ── workflow_run.completed ─────────────────────────────────────────────────
 
 	test("workflow_run.completed failure → check_failed event", async () => {
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"workflow_run",
 			"delivery-014",
 			workflowRunFailure,
@@ -462,7 +462,7 @@ describe("WebhookRouter", () => {
 	});
 
 	test("workflow_run.completed success → skipped", async () => {
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"workflow_run",
 			"delivery-015",
 			workflowRunSuccess,
@@ -476,7 +476,7 @@ describe("WebhookRouter", () => {
 	// ── unknown event ─────────────────────────────────────────────────────────
 
 	test("unknown event → skipped", async () => {
-		const result = await router.handleWebhook("push", "delivery-016", {
+		const result = await router.handleGithubWebhook("push", "delivery-016", {
 			ref: "refs/heads/main",
 		});
 
@@ -492,7 +492,7 @@ describe("WebhookRouter", () => {
 			...issuesAssigned,
 			installation: { id: 77777 },
 		};
-		const result = await router.handleWebhook(
+		const result = await router.handleGithubWebhook(
 			"issues",
 			"delivery-017",
 			payload,

--- a/src/webhooks/github/router.ts
+++ b/src/webhooks/github/router.ts
@@ -73,7 +73,7 @@ export class WebhookRouter {
 	 * event name and action. Each event.action pair maps directly to a
 	 * strongly-typed octokit payload type via type assertion.
 	 */
-	async handleWebhook(
+	async handleGithubWebhook(
 		eventName: string,
 		deliveryId: string,
 		payload: unknown,

--- a/src/workflows/AGENTS.md
+++ b/src/workflows/AGENTS.md
@@ -69,7 +69,7 @@ export interface RunFooContext {
 export async function runFoo(ctx: RunFooContext): Promise<void> { /* ... */ }
 ```
 
-`CoderTaskWorkflow.run()` constructs `coder` and `github` once at the top and passes them through. That's the DI seam — tests pass fakes directly without patching module-level imports. Adding a new factory? Mirror the shape exactly; the workflow dispatch relies on it.
+`TaskRunnerWorkflow.run()` constructs `coder` and `github` once at the top and passes them through. That's the DI seam — tests pass fakes directly without patching module-level imports. Adding a new factory? Mirror the shape exactly; the workflow dispatch relies on it.
 
 ## Paused tasks: resume only in pre-poll dispatch
 

--- a/src/workflows/task-runner-workflow.test.ts
+++ b/src/workflows/task-runner-workflow.test.ts
@@ -7,20 +7,20 @@ import type {
 	TaskClosedEvent,
 	TaskRequestedEvent,
 } from "../events/types";
-import { CoderTaskWorkflow } from "./coder-task-workflow";
+import { TaskRunnerWorkflow } from "./task-runner-workflow";
 
 // ── Smoke: binding shape ─────────────────────────────────────────────────────
 
-describe("CoderTaskWorkflow", () => {
+describe("TaskRunnerWorkflow", () => {
 	test("class is exported and its name matches wrangler.toml class_name", () => {
 		// A rename would orphan in-flight instances — this guards against that.
-		expect(typeof CoderTaskWorkflow).toBe("function");
-		expect(CoderTaskWorkflow.name).toBe("CoderTaskWorkflow");
+		expect(typeof TaskRunnerWorkflow).toBe("function");
+		expect(TaskRunnerWorkflow.name).toBe("TaskRunnerWorkflow");
 	});
 
-	test("env.CODER_TASK_WORKFLOW binding exists and is callable", () => {
-		expect(env.CODER_TASK_WORKFLOW).toBeDefined();
-		expect(typeof env.CODER_TASK_WORKFLOW.create).toBe("function");
+	test("env.TASK_RUNNER_WORKFLOW binding exists and is callable", () => {
+		expect(env.TASK_RUNNER_WORKFLOW).toBeDefined();
+		expect(typeof env.TASK_RUNNER_WORKFLOW.create).toBe("function");
 	});
 });
 
@@ -33,11 +33,11 @@ describe("CoderTaskWorkflow", () => {
 //   3. Creates the workflow instance with a representative `Event` payload.
 //   4. Asserts the instance reaches the `complete` status.
 
-describe("CoderTaskWorkflow dispatch — task_requested", () => {
+describe("TaskRunnerWorkflow dispatch — task_requested", () => {
 	test("executes lookup → permission → create → comment and completes", async () => {
 		const instanceId = "task_requested-repo-1-test-delivery";
 		await using instance = await introspectWorkflowInstance(
-			env.CODER_TASK_WORKFLOW,
+			env.TASK_RUNNER_WORKFLOW,
 			instanceId,
 		);
 		await instance.modify(async (m) => {
@@ -63,7 +63,7 @@ describe("CoderTaskWorkflow dispatch — task_requested", () => {
 			issue: { number: 1, url: "https://github.com/acme/repo/issues/1" },
 			requester: { login: "alice", externalId: 42 },
 		};
-		await env.CODER_TASK_WORKFLOW.create({ id: instanceId, params });
+		await env.TASK_RUNNER_WORKFLOW.create({ id: instanceId, params });
 		await expect(instance.waitForStatus("complete")).resolves.not.toThrow();
 	});
 
@@ -76,11 +76,11 @@ describe("CoderTaskWorkflow dispatch — task_requested", () => {
 	// not a defect in our workflow logic.
 });
 
-describe("CoderTaskWorkflow dispatch — task_closed", () => {
+describe("TaskRunnerWorkflow dispatch — task_closed", () => {
 	test("executes delete → comment and completes", async () => {
 		const instanceId = "task_closed-repo-1-test-delivery";
 		await using instance = await introspectWorkflowInstance(
-			env.CODER_TASK_WORKFLOW,
+			env.TASK_RUNNER_WORKFLOW,
 			instanceId,
 		);
 		await instance.modify(async (m) => {
@@ -95,14 +95,14 @@ describe("CoderTaskWorkflow dispatch — task_closed", () => {
 			repository: { owner: "acme", name: "repo" },
 			issue: { number: 1 },
 		};
-		await env.CODER_TASK_WORKFLOW.create({ id: instanceId, params });
+		await env.TASK_RUNNER_WORKFLOW.create({ id: instanceId, params });
 		await expect(instance.waitForStatus("complete")).resolves.not.toThrow();
 	});
 
 	test("no-op when task not found (deleted: false) — comment step is skipped", async () => {
 		const instanceId = "task_closed-repo-2-noop";
 		await using instance = await introspectWorkflowInstance(
-			env.CODER_TASK_WORKFLOW,
+			env.TASK_RUNNER_WORKFLOW,
 			instanceId,
 		);
 		await instance.modify(async (m) => {
@@ -118,16 +118,16 @@ describe("CoderTaskWorkflow dispatch — task_closed", () => {
 			repository: { owner: "acme", name: "repo" },
 			issue: { number: 2 },
 		};
-		await env.CODER_TASK_WORKFLOW.create({ id: instanceId, params });
+		await env.TASK_RUNNER_WORKFLOW.create({ id: instanceId, params });
 		await expect(instance.waitForStatus("complete")).resolves.not.toThrow();
 	});
 });
 
-describe("CoderTaskWorkflow dispatch — comment_posted", () => {
+describe("TaskRunnerWorkflow dispatch — comment_posted", () => {
 	test("issue-kind comment: locate → ensureReady → send → react completes", async () => {
 		const instanceId = "comment_posted-repo-1-issue";
 		await using instance = await introspectWorkflowInstance(
-			env.CODER_TASK_WORKFLOW,
+			env.TASK_RUNNER_WORKFLOW,
 			instanceId,
 		);
 		await instance.modify(async (m) => {
@@ -160,14 +160,14 @@ describe("CoderTaskWorkflow dispatch — comment_posted", () => {
 				isReviewSubmission: false,
 			},
 		};
-		await env.CODER_TASK_WORKFLOW.create({ id: instanceId, params });
+		await env.TASK_RUNNER_WORKFLOW.create({ id: instanceId, params });
 		await expect(instance.waitForStatus("complete")).resolves.not.toThrow();
 	});
 
 	test("pr-kind review comment dispatches react-to-review-comment variant", async () => {
 		const instanceId = "comment_posted-repo-2-pr-review";
 		await using instance = await introspectWorkflowInstance(
-			env.CODER_TASK_WORKFLOW,
+			env.TASK_RUNNER_WORKFLOW,
 			instanceId,
 		);
 		await instance.modify(async (m) => {
@@ -208,14 +208,14 @@ describe("CoderTaskWorkflow dispatch — comment_posted", () => {
 				lineNumber: 5,
 			},
 		};
-		await env.CODER_TASK_WORKFLOW.create({ id: instanceId, params });
+		await env.TASK_RUNNER_WORKFLOW.create({ id: instanceId, params });
 		await expect(instance.waitForStatus("complete")).resolves.not.toThrow();
 	});
 
 	test("paused task triggers resume step in ensureTaskReady pre-poll dispatch", async () => {
 		const instanceId = "comment_posted-repo-3-paused-resume";
 		await using instance = await introspectWorkflowInstance(
-			env.CODER_TASK_WORKFLOW,
+			env.TASK_RUNNER_WORKFLOW,
 			instanceId,
 		);
 		await instance.modify(async (m) => {
@@ -253,16 +253,16 @@ describe("CoderTaskWorkflow dispatch — comment_posted", () => {
 				isReviewSubmission: false,
 			},
 		};
-		await env.CODER_TASK_WORKFLOW.create({ id: instanceId, params });
+		await env.TASK_RUNNER_WORKFLOW.create({ id: instanceId, params });
 		await expect(instance.waitForStatus("complete")).resolves.not.toThrow();
 	});
 });
 
-describe("CoderTaskWorkflow dispatch — check_failed", () => {
+describe("TaskRunnerWorkflow dispatch — check_failed", () => {
 	test("fetches PR → linked issues → locate task → logs → send, completes", async () => {
 		const instanceId = "check_failed-repo-1-test-delivery";
 		await using instance = await introspectWorkflowInstance(
-			env.CODER_TASK_WORKFLOW,
+			env.TASK_RUNNER_WORKFLOW,
 			instanceId,
 		);
 		await instance.modify(async (m) => {
@@ -307,7 +307,7 @@ describe("CoderTaskWorkflow dispatch — check_failed", () => {
 			},
 			pullRequestNumbers: [42],
 		};
-		await env.CODER_TASK_WORKFLOW.create({ id: instanceId, params });
+		await env.TASK_RUNNER_WORKFLOW.create({ id: instanceId, params });
 		await expect(instance.waitForStatus("complete")).resolves.not.toThrow();
 	});
 

--- a/src/workflows/task-runner-workflow.ts
+++ b/src/workflows/task-runner-workflow.ts
@@ -20,7 +20,7 @@ import { runFailedCheck } from "./steps/failed-check";
  * `wrangler secret put` in production and `.dev.vars` locally; `[vars]`
  * entries in `wrangler.toml` supply non-secret config.
  */
-export interface CoderTaskWorkflowEnv {
+export interface TaskRunnerWorkflowEnv {
 	APP_ID: string;
 	PRIVATE_KEY: string;
 	WEBHOOK_SECRET: string;
@@ -33,11 +33,11 @@ export interface CoderTaskWorkflowEnv {
 	CODER_TEMPLATE_PRESET?: string;
 	CODER_ORGANIZATION: string;
 	LOG_FORMAT?: string;
-	CODER_TASK_WORKFLOW: Workflow;
+	TASK_RUNNER_WORKFLOW: Workflow;
 }
 
 /**
- * `CoderTaskWorkflow` runs one instance per GitHub delivery that our webhook
+ * `TaskRunnerWorkflow` runs one instance per GitHub delivery that our webhook
  * router accepts. It dispatches on `event.payload.type` to the appropriate
  * step factory, each of which wraps external side-effects in `step.do` calls
  * so they can be retried, cached across replays, and inspected via
@@ -48,8 +48,8 @@ export interface CoderTaskWorkflowEnv {
  * callback — class instances are not structured-cloneable and the workflow
  * engine throws on attempted persistence. See src/workflows/AGENTS.md.
  */
-export class CoderTaskWorkflow extends WorkflowEntrypoint<
-	CoderTaskWorkflowEnv,
+export class TaskRunnerWorkflow extends WorkflowEntrypoint<
+	TaskRunnerWorkflowEnv,
 	Event
 > {
 	async run(event: WorkflowEvent<Event>, step: WorkflowStep): Promise<void> {

--- a/tests/config/wrangler-config.test.ts
+++ b/tests/config/wrangler-config.test.ts
@@ -13,11 +13,11 @@ describe("wrangler.toml", () => {
 		expect(content).toMatch(/compatibility_flags\s*=\s*\[\s*"nodejs_compat"\s*\]/);
 	});
 
-	test("declares the CODER_TASK_WORKFLOW binding", () => {
+	test("declares the TASK_RUNNER_WORKFLOW binding", () => {
 		expect(content).toMatch(
-			/\[\[workflows\]\][\s\S]*binding\s*=\s*"CODER_TASK_WORKFLOW"/,
+			/\[\[workflows\]\][\s\S]*binding\s*=\s*"TASK_RUNNER_WORKFLOW"/,
 		);
-		expect(content).toMatch(/class_name\s*=\s*"CoderTaskWorkflow"/);
+		expect(content).toMatch(/class_name\s*=\s*"TaskRunnerWorkflow"/);
 	});
 
 	test("enables observability for Workers Logs", () => {

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -13,7 +13,7 @@ declare namespace Cloudflare {
 		CODER_TEMPLATE_NAME_CODEX: "task-template-codex";
 		CODER_ORGANIZATION: "default";
 		LOG_FORMAT: "json";
-		CODER_TASK_WORKFLOW: Workflow<Parameters<import("./src/main").CoderTaskWorkflow['run']>[0]['payload']>;
+		TASK_RUNNER_WORKFLOW: Workflow<Parameters<import("./src/main").TaskRunnerWorkflow['run']>[0]['payload']>;
 	}
 }
 interface Env extends Cloudflare.Env {}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,9 +5,9 @@ compatibility_date = "2026-04-18"
 compatibility_flags = ["nodejs_compat"]
 
 [[workflows]]
-name = "coder-task-workflow"
-binding = "CODER_TASK_WORKFLOW"
-class_name = "CoderTaskWorkflow"
+name = "task-runner-workflow"
+binding = "TASK_RUNNER_WORKFLOW"
+class_name = "TaskRunnerWorkflow"
 
 [limits]
 cpu_ms = 30000


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/104

## Summary

Generic-name renames per the issue — behavior is unchanged, identifiers only.

| Old | New |
|-----|-----|
| Route `/api/webhooks` | `/webhooks/github` |
| Function/method `handleWebhook` | `handleGithubWebhook` |
| Workflow config name `coder-task-workflow` | `task-runner-workflow` |
| Binding `CODER_TASK_WORKFLOW` | `TASK_RUNNER_WORKFLOW` |
| Class `CoderTaskWorkflow` | `TaskRunnerWorkflow` |
| Interface `CoderTaskWorkflowEnv` | `TaskRunnerWorkflowEnv` |
| `src/workflows/coder-task-workflow.{ts,test.ts}` | `src/workflows/task-runner-workflow.{ts,test.ts}` (via `git mv`) |

## Notes

- `worker-configuration.d.ts` (generated by `wrangler types`) was updated by hand to match the new binding/class names — regenerating via `wrangler types` locally should produce the same diff.
- Fixture JSON files (`src/testing/fixtures/pr-review-*.json`) contain the string `handleWebhook` inside historical PR-description text captured from past GitHub webhook payloads; those are deliberately left untouched.
- Deployment-side action required: after merge, redeploy the worker, then update the GitHub App's Webhook URL in its settings from `.../api/webhooks` to `.../webhooks/github`. The new binding name means in-flight workflow instances from the old name would be orphaned — if any are expected to be in flight at deploy time, run `migrateWorkflowBinding()` as described in `docs/gotchas.md`.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` — 246 tests pass
- [ ] Manual verification post-deploy: signed webhook to `/webhooks/github` → 202

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename webhook path, handler, and workflow to generic names
> - Renames the GitHub webhook route from `POST /api/webhooks` to `POST /webhooks/github` in [src/main.ts](https://github.com/xmtplabs/coder-action/pull/105/files#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3d) and all tests.
> - Renames `CoderTaskWorkflow`/`CODER_TASK_WORKFLOW` to `TaskRunnerWorkflow`/`TASK_RUNNER_WORKFLOW` across the workflow class, env interface, wrangler config, and generated types.
> - Renames `WebhookRouter.handleWebhook` to `WebhookRouter.handleGithubWebhook` in [src/webhooks/github/router.ts](https://github.com/xmtplabs/coder-action/pull/105/files#diff-cec793eb96fa8b59a40b699c0a01e21bfbfd4c2e8ac48ac21f6a00739cf5b021) and updates all call sites.
> - Updates all documentation and AGENTS.md files to reflect the new names.
> - Risk: the webhook URL change is a breaking change for any GitHub App already configured to POST to `/api/webhooks`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5090ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->