### PR TITLE
Wait for sandbox boot and update issue comment with status

### DIFF
--- a/src/testing/e2e.test.ts
+++ b/src/testing/e2e.test.ts
@@ -53,11 +53,18 @@ describe("e2e: signed webhook → worker → workflow completion", () => {
 				{
 					taskName: "gh-coder-action-65",
 					owner: "coder-user",
+					taskId: "11111111-1111-4111-8111-111111111111",
 					url: "https://coder.example.com/tasks/coder-user/abc",
 					status: "ready",
 				},
 			);
 			await m.mockStepResult({ name: "comment-on-issue" }, {});
+			// waitForTaskActive pre-poll fast-path.
+			await m.mockStepResult(
+				{ name: "wait-lookup-task" },
+				{ status: "active" },
+			);
+			await m.mockStepResult({ name: "update-status-comment" }, {});
 		});
 
 		const req = await buildSignedWebhookRequest({

--- a/src/workflows/steps/close-task.test.ts
+++ b/src/workflows/steps/close-task.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test, vi } from "vitest";
 import type { AppConfig } from "../../config/app-config";
 import type { TaskClosedEvent } from "../../events/types";
+import {
+	TASK_STATUS_COMMENT_MARKER,
+	buildTaskStatusCommentBody,
+} from "../task-status-comment";
 import { runCloseTask } from "./close-task";
 
 function makeStep() {
@@ -61,6 +65,35 @@ describe("runCloseTask", () => {
 		});
 		expect(step.calls).toEqual(["delete-coder-task"]);
 		expect(github.commentOnIssue).not.toHaveBeenCalled();
+	});
+
+	test("comment-on-issue uses TASK_STATUS_COMMENT_MARKER as matchPrefix and body starts with it", async () => {
+		const step = makeStep();
+		const coder = {
+			delete: vi.fn(async () => ({ deleted: true })),
+		};
+		const github = {
+			commentOnIssue: vi.fn(async () => {}),
+		};
+		await runCloseTask({
+			step: step as never,
+			coder: coder as never,
+			github: github as never,
+			config,
+			event,
+		});
+		expect(github.commentOnIssue).toHaveBeenCalledTimes(1);
+		const call = github.commentOnIssue.mock.calls[0] as unknown as [
+			string,
+			string,
+			number,
+			string,
+			string,
+		];
+		const [, , , body, matchPrefix] = call;
+		expect(matchPrefix).toBe(TASK_STATUS_COMMENT_MARKER);
+		expect(body).toBe(buildTaskStatusCommentBody("Task completed."));
+		expect(body.startsWith(TASK_STATUS_COMMENT_MARKER)).toBe(true);
 	});
 
 	test("delete-coder-task step output projects ONLY `{deleted}` (strips any extra fields returned by the coder client)", async () => {

--- a/src/workflows/steps/close-task.ts
+++ b/src/workflows/steps/close-task.ts
@@ -4,6 +4,10 @@ import type { AppConfig } from "../../config/app-config";
 import type { TaskClosedEvent } from "../../events/types";
 import type { CoderService } from "../../services/coder/service";
 import type { GitHubClient } from "../../services/github/client";
+import {
+	TASK_STATUS_COMMENT_MARKER,
+	buildTaskStatusCommentBody,
+} from "../task-status-comment";
 
 export interface RunCloseTaskContext {
 	step: WorkflowStep;
@@ -43,8 +47,8 @@ export async function runCloseTask(ctx: RunCloseTaskContext): Promise<void> {
 			event.repository.owner,
 			event.repository.name,
 			event.issue.number,
-			"Task completed.",
-			"Task created:",
+			buildTaskStatusCommentBody("Task completed."),
+			TASK_STATUS_COMMENT_MARKER,
 		);
 	});
 }

--- a/src/workflows/steps/comment.test.ts
+++ b/src/workflows/steps/comment.test.ts
@@ -100,7 +100,7 @@ function commentEvent(
 // ── Step sequencing + reaction routing ───────────────────────────────────────
 
 describe("runComment — step order + reaction routing", () => {
-	test("PR comment: find-linked-issues → locate-task → ensureReady → send → react", async () => {
+	test("PR comment: find-linked-issues → locate-task → react → ensureReady → send", async () => {
 		const step = makeStep();
 		const coder = makeCoder();
 		const github = makeGithub();
@@ -114,16 +114,24 @@ describe("runComment — step order + reaction routing", () => {
 		});
 
 		// PR-kind comments resolve the linked issue FIRST, then locate the task.
+		// react-to-comment fires BEFORE ensureTaskReady so users see the eyes
+		// reaction without waiting on poll latency.
 		expect(step.calls[0]).toBe("find-linked-issues");
 		expect(step.calls[1]).toBe("locate-task");
+		expect(step.calls[2]).toBe("react-to-comment");
 		expect(step.calls).toContain("lookup-task"); // ensureTaskReady
 		expect(step.calls).toContain("send-task-input");
-		expect(step.calls).toContain("react-to-comment");
+		// react must appear BEFORE ensureTaskReady's lookup-task.
+		const reactIdx = step.calls.indexOf("react-to-comment");
+		const readyIdx = step.calls.indexOf("lookup-task");
+		const sendIdx = step.calls.indexOf("send-task-input");
+		expect(reactIdx).toBeLessThan(readyIdx);
+		expect(readyIdx).toBeLessThan(sendIdx);
 		expect(github.addReactionToComment).toHaveBeenCalled();
 		expect(github.addReactionToReviewComment).not.toHaveBeenCalled();
 	});
 
-	test("issue comment: locate-task is the FIRST step (no find-linked-issues)", async () => {
+	test("issue comment: locate-task is the FIRST step (no find-linked-issues), then react → ensureReady → send", async () => {
 		const step = makeStep();
 		const coder = makeCoder();
 		const github = makeGithub();
@@ -140,9 +148,15 @@ describe("runComment — step order + reaction routing", () => {
 		// no linked-issue lookup needed, and calling findLinkedIssues for a
 		// non-PR number would 404 on GitHub.
 		expect(step.calls[0]).toBe("locate-task");
+		expect(step.calls[1]).toBe("react-to-comment");
 		expect(step.calls).not.toContain("find-linked-issues");
 		expect(github.findLinkedIssues).not.toHaveBeenCalled();
 		expect(step.calls).toContain("send-task-input");
+		const reactIdx = step.calls.indexOf("react-to-comment");
+		const readyIdx = step.calls.indexOf("lookup-task");
+		const sendIdx = step.calls.indexOf("send-task-input");
+		expect(reactIdx).toBeLessThan(readyIdx);
+		expect(readyIdx).toBeLessThan(sendIdx);
 	});
 
 	test("PR review comment uses review-comment reaction endpoint", async () => {

--- a/src/workflows/steps/comment.ts
+++ b/src/workflows/steps/comment.ts
@@ -116,13 +116,8 @@ export async function runComment(ctx: RunCommentContext): Promise<void> {
 
 	const taskId = TaskIdSchema.parse(located.taskId);
 
-	await ensureTaskReady({ step, coder, taskId, owner: located.owner });
-
-	const message = buildCommentMessage(event);
-	await step.do("send-task-input", async () => {
-		await coder.sendTaskInput(taskId, located.owner, message);
-	});
-
+	// React immediately after locating the task so the user sees the eyes
+	// reaction without waiting on readiness-poll latency.
 	await step.do("react-to-comment", async () => {
 		if (event.comment.isReviewComment) {
 			await github.addReactionToReviewComment(
@@ -137,5 +132,12 @@ export async function runComment(ctx: RunCommentContext): Promise<void> {
 				event.comment.id,
 			);
 		}
+	});
+
+	await ensureTaskReady({ step, coder, taskId, owner: located.owner });
+
+	const message = buildCommentMessage(event);
+	await step.do("send-task-input", async () => {
+		await coder.sendTaskInput(taskId, located.owner, message);
 	});
 }

--- a/src/workflows/steps/create-task.test.ts
+++ b/src/workflows/steps/create-task.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test, vi } from "vitest";
 import type { AppConfig } from "../../config/app-config";
 import type { TaskRequestedEvent } from "../../events/types";
+import {
+	TASK_STATUS_COMMENT_MARKER,
+	buildTaskStatusCommentBody,
+} from "../task-status-comment";
 import { runCreateTask } from "./create-task";
 
 function makeStep() {
@@ -12,6 +16,7 @@ function makeStep() {
 			const fn = rest[rest.length - 1] as () => Promise<unknown>;
 			return fn();
 		}),
+		sleep: vi.fn(async () => {}),
 	};
 	return step;
 }
@@ -28,23 +33,39 @@ const config = {
 	coderTaskNamePrefix: "gh",
 } as unknown as AppConfig;
 
+function makeCoder(overrides: Record<string, unknown> = {}) {
+	return {
+		lookupUser: vi.fn(async () => "coder-user"),
+		create: vi.fn(async () => ({
+			id: "11111111-1111-4111-8111-111111111111",
+			name: "gh-repo-42",
+			status: "ready",
+			owner: "coder-user",
+			url: "https://coder/t",
+		})),
+		getTaskById: vi.fn(async () => ({
+			id: "11111111-1111-4111-8111-111111111111",
+			status: "active",
+			current_state: null,
+			workspace_id: "ws-1",
+		})),
+		...overrides,
+	};
+}
+
+function makeGithub(overrides: Record<string, unknown> = {}) {
+	return {
+		checkActorPermission: vi.fn(async () => true),
+		commentOnIssue: vi.fn(async () => {}),
+		...overrides,
+	};
+}
+
 describe("runCreateTask", () => {
-	test("emits steps in order: check-github-permission (first), lookup-coder-user, create-coder-task, comment-on-issue", async () => {
+	test("emits steps in order: check-github-permission (first), lookup-coder-user, create-coder-task, comment-on-issue, wait-*, update-status-comment", async () => {
 		const step = makeStep();
-		const coder = {
-			lookupUser: vi.fn(async () => "coder-user"),
-			create: vi.fn(async () => ({
-				id: "task-uuid-1",
-				name: "gh-repo-42",
-				status: "ready",
-				owner: "coder-user",
-				url: "https://coder/t",
-			})),
-		};
-		const github = {
-			checkActorPermission: vi.fn(async () => true),
-			commentOnIssue: vi.fn(async () => {}),
-		};
+		const coder = makeCoder();
+		const github = makeGithub();
 
 		await runCreateTask({
 			step: step as never,
@@ -53,30 +74,24 @@ describe("runCreateTask", () => {
 			config,
 			event,
 		});
+		// With a fast-path `active` observation at pre-poll, waitForTaskActive
+		// emits exactly one step (`wait-lookup-task`).
 		expect(step.calls).toEqual([
 			"check-github-permission",
 			"lookup-coder-user",
 			"create-coder-task",
 			"comment-on-issue",
+			"wait-lookup-task",
+			"update-status-comment",
 		]);
 	});
 
-	test("skips lookup + create + comment if actor lacks write permission", async () => {
+	test("skips lookup + create + comment + wait + update if actor lacks write permission", async () => {
 		const step = makeStep();
-		const coder = {
-			lookupUser: vi.fn(async () => "coder-user"),
-			create: vi.fn(async () => ({
-				id: "unused",
-				name: "x",
-				status: "ready",
-				owner: "x",
-				url: "u",
-			})),
-		};
-		const github = {
+		const coder = makeCoder();
+		const github = makeGithub({
 			checkActorPermission: vi.fn(async () => false),
-			commentOnIssue: vi.fn(async () => {}),
-		};
+		});
 		await runCreateTask({
 			step: step as never,
 			coder: coder as never,
@@ -86,28 +101,16 @@ describe("runCreateTask", () => {
 		});
 		// Only the permission check ran.
 		expect(step.calls).toEqual(["check-github-permission"]);
-		// Neither Coder nor GitHub comment-on-issue hit.
 		expect(coder.lookupUser).not.toHaveBeenCalled();
 		expect(coder.create).not.toHaveBeenCalled();
+		expect(coder.getTaskById).not.toHaveBeenCalled();
 		expect(github.commentOnIssue).not.toHaveBeenCalled();
 	});
 
 	test("create-coder-task step returns exactly the spec §4 scalar projection", async () => {
 		const step = makeStep();
-		const coder = {
-			lookupUser: vi.fn(async () => "coder-user"),
-			create: vi.fn(async () => ({
-				id: "11111111-1111-4111-8111-111111111111",
-				name: "gh-repo-42",
-				status: "ready",
-				owner: "coder-user",
-				url: "https://coder/t",
-			})),
-		};
-		const github = {
-			checkActorPermission: vi.fn(async () => true),
-			commentOnIssue: vi.fn(async () => {}),
-		};
+		const coder = makeCoder();
+		const github = makeGithub();
 		await runCreateTask({
 			step: step as never,
 			coder: coder as never,
@@ -128,5 +131,143 @@ describe("runCreateTask", () => {
 			url: "https://coder/t",
 			status: "ready",
 		});
+	});
+
+	test("initial comment-on-issue uses the shared marker as matchPrefix and the body starts with the marker", async () => {
+		const step = makeStep();
+		const coder = makeCoder();
+		const github = makeGithub();
+		await runCreateTask({
+			step: step as never,
+			coder: coder as never,
+			github: github as never,
+			config,
+			event,
+		});
+		// First commentOnIssue call — the initial "Task created" comment.
+		const firstCall = github.commentOnIssue.mock.calls[0] as unknown as [
+			string,
+			string,
+			number,
+			string,
+			string,
+		];
+		const [, , , body, matchPrefix] = firstCall;
+		expect(matchPrefix).toBe(TASK_STATUS_COMMENT_MARKER);
+		expect(body.startsWith(TASK_STATUS_COMMENT_MARKER)).toBe(true);
+		expect(body).toBe(
+			buildTaskStatusCommentBody("Task created: https://coder/t"),
+		);
+	});
+
+	test("when waitForTaskActive returns 'active' → update-status-comment posts running message with marker", async () => {
+		const step = makeStep();
+		// Pre-poll 'initializing', then 'active' at attempt 1.
+		let call = 0;
+		const coder = makeCoder({
+			getTaskById: vi.fn(async () => {
+				const s = call === 0 ? "initializing" : "active";
+				call++;
+				return {
+					id: "11111111-1111-4111-8111-111111111111",
+					status: s,
+					current_state: null,
+					workspace_id: "ws-1",
+				};
+			}),
+		});
+		const github = makeGithub();
+		await runCreateTask({
+			step: step as never,
+			coder: coder as never,
+			github: github as never,
+			config,
+			event,
+		});
+
+		expect(step.calls).toContain("update-status-comment");
+
+		// Final commentOnIssue (update) should carry the running message.
+		const last =
+			github.commentOnIssue.mock.calls[
+				github.commentOnIssue.mock.calls.length - 1
+			];
+		const [, , , body, matchPrefix] = last as unknown as [
+			string,
+			string,
+			number,
+			string,
+			string,
+		];
+		expect(matchPrefix).toBe(TASK_STATUS_COMMENT_MARKER);
+		expect(body).toBe(
+			buildTaskStatusCommentBody("Task is running: https://coder/t"),
+		);
+	});
+
+	test("when waitForTaskActive returns 'error' → update-status-comment posts failure message with marker", async () => {
+		const step = makeStep();
+		// Every status read returns 'paused' → immediate error.
+		const coder = makeCoder({
+			getTaskById: vi.fn(async () => ({
+				id: "11111111-1111-4111-8111-111111111111",
+				status: "paused",
+				current_state: null,
+				workspace_id: "ws-1",
+			})),
+		});
+		const github = makeGithub();
+		await runCreateTask({
+			step: step as never,
+			coder: coder as never,
+			github: github as never,
+			config,
+			event,
+		});
+
+		expect(step.calls).toContain("update-status-comment");
+
+		const last =
+			github.commentOnIssue.mock.calls[
+				github.commentOnIssue.mock.calls.length - 1
+			];
+		const [, , , body, matchPrefix] = last as unknown as [
+			string,
+			string,
+			number,
+			string,
+			string,
+		];
+		expect(matchPrefix).toBe(TASK_STATUS_COMMENT_MARKER);
+		expect(body).toBe(
+			buildTaskStatusCommentBody(
+				"Failed to create task sandbox: https://coder/t",
+			),
+		);
+	});
+
+	test("every commentOnIssue invocation uses TASK_STATUS_COMMENT_MARKER as matchPrefix and body starts with it", async () => {
+		const step = makeStep();
+		const coder = makeCoder();
+		const github = makeGithub();
+		await runCreateTask({
+			step: step as never,
+			coder: coder as never,
+			github: github as never,
+			config,
+			event,
+		});
+		expect(github.commentOnIssue).toHaveBeenCalledTimes(2);
+		for (const call of github.commentOnIssue.mock.calls) {
+			const [, , , body, matchPrefix] = call as unknown as [
+				string,
+				string,
+				number,
+				string,
+				string,
+			];
+			expect(matchPrefix).toBe(TASK_STATUS_COMMENT_MARKER);
+			expect(body.startsWith(TASK_STATUS_COMMENT_MARKER)).toBe(true);
+		}
 	});
 });

--- a/src/workflows/steps/create-task.ts
+++ b/src/workflows/steps/create-task.ts
@@ -4,6 +4,12 @@ import type { AppConfig } from "../../config/app-config";
 import type { TaskRequestedEvent } from "../../events/types";
 import type { CoderService } from "../../services/coder/service";
 import type { GitHubClient } from "../../services/github/client";
+import { TaskIdSchema } from "../../services/task-runner";
+import {
+	TASK_STATUS_COMMENT_MARKER,
+	buildTaskStatusCommentBody,
+} from "../task-status-comment";
+import { waitForTaskActive } from "../wait-for-task-active";
 
 export interface RunCreateTaskContext {
 	step: WorkflowStep;
@@ -73,8 +79,33 @@ export async function runCreateTask(ctx: RunCreateTaskContext): Promise<void> {
 			event.repository.owner,
 			event.repository.name,
 			event.issue.number,
-			`Task created: ${created.url}`,
-			"Task created:",
+			buildTaskStatusCommentBody(`Task created: ${created.url}`),
+			TASK_STATUS_COMMENT_MARKER,
+		);
+	});
+
+	// Block until the sandbox reaches raw `status === "active"` (or a terminal
+	// error). Looser than `ensureTaskReady`: we don't inspect `current_state`
+	// here — the user only needs to see "running" vs "failed" in the issue
+	// comment as soon as the sandbox is up.
+	const waitResult = await waitForTaskActive({
+		step,
+		coder,
+		taskId: TaskIdSchema.parse(created.taskId),
+		owner: created.owner,
+	});
+
+	await step.do("update-status-comment", async () => {
+		const content =
+			waitResult === "active"
+				? `Task is running: ${created.url}`
+				: `Failed to create task sandbox: ${created.url}`;
+		await github.commentOnIssue(
+			event.repository.owner,
+			event.repository.name,
+			event.issue.number,
+			buildTaskStatusCommentBody(content),
+			TASK_STATUS_COMMENT_MARKER,
 		);
 	});
 }

--- a/src/workflows/task-runner-workflow.test.ts
+++ b/src/workflows/task-runner-workflow.test.ts
@@ -49,11 +49,18 @@ describe("TaskRunnerWorkflow dispatch — task_requested", () => {
 				{
 					taskName: "gh-repo-1",
 					owner: "coder-user",
+					taskId: "11111111-1111-4111-8111-111111111111",
 					url: "https://coder.example.com/tasks/coder-user/abc",
 					status: "ready",
 				},
 			);
 			await m.mockStepResult({ name: "comment-on-issue" }, {});
+			// waitForTaskActive pre-poll hits 'active' → fast-path, no loop steps.
+			await m.mockStepResult(
+				{ name: "wait-lookup-task" },
+				{ status: "active" },
+			);
+			await m.mockStepResult({ name: "update-status-comment" }, {});
 		});
 
 		const params: TaskRequestedEvent = {
@@ -141,8 +148,8 @@ describe("TaskRunnerWorkflow dispatch — comment_posted", () => {
 				{ name: "lookup-task" },
 				{ status: "active", state: "idle", workspaceId: "ws-1" },
 			);
-			await m.mockStepResult({ name: "send-task-input" }, {});
 			await m.mockStepResult({ name: "react-to-comment" }, {});
+			await m.mockStepResult({ name: "send-task-input" }, {});
 		});
 
 		const params: CommentPostedEvent = {
@@ -183,8 +190,8 @@ describe("TaskRunnerWorkflow dispatch — comment_posted", () => {
 				{ name: "lookup-task" },
 				{ status: "active", state: "idle", workspaceId: "ws-2" },
 			);
-			await m.mockStepResult({ name: "send-task-input" }, {});
 			await m.mockStepResult({ name: "react-to-comment" }, {});
+			await m.mockStepResult({ name: "send-task-input" }, {});
 		});
 
 		const params: CommentPostedEvent = {
@@ -234,8 +241,8 @@ describe("TaskRunnerWorkflow dispatch — comment_posted", () => {
 				{ name: "check-status-1" },
 				{ status: "active", state: "idle" },
 			);
-			await m.mockStepResult({ name: "send-task-input" }, {});
 			await m.mockStepResult({ name: "react-to-comment" }, {});
+			await m.mockStepResult({ name: "send-task-input" }, {});
 		});
 
 		const params: CommentPostedEvent = {

--- a/src/workflows/task-status-comment.test.ts
+++ b/src/workflows/task-status-comment.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import {
+	TASK_STATUS_COMMENT_MARKER,
+	buildTaskStatusCommentBody,
+} from "./task-status-comment";
+
+describe("buildTaskStatusCommentBody", () => {
+	test("prepends the marker on its own line followed by the content", () => {
+		const body = buildTaskStatusCommentBody("Task created: https://x");
+		expect(body).toBe(`${TASK_STATUS_COMMENT_MARKER}\nTask created: https://x`);
+	});
+
+	test("body starts with the marker so startsWith(marker) matches", () => {
+		const body = buildTaskStatusCommentBody("Anything here");
+		expect(body.startsWith(TASK_STATUS_COMMENT_MARKER)).toBe(true);
+	});
+
+	test("marker is a hidden HTML comment (invisible in rendered markdown)", () => {
+		expect(TASK_STATUS_COMMENT_MARKER.startsWith("<!--")).toBe(true);
+		expect(TASK_STATUS_COMMENT_MARKER.endsWith("-->")).toBe(true);
+	});
+});

--- a/src/workflows/task-status-comment.ts
+++ b/src/workflows/task-status-comment.ts
@@ -1,0 +1,19 @@
+/**
+ * Hidden HTML-comment marker prepended to every workflow-written issue comment
+ * that may be edited in place across steps (create → update → close). The
+ * marker is invisible in rendered markdown; GitHub's `listComments` response
+ * preserves it, so `GitHubClient.commentOnIssue`'s `startsWith(matchPrefix)`
+ * upsert resolves the same comment regardless of the visible body each writer
+ * chose. Always pair with `matchPrefix = TASK_STATUS_COMMENT_MARKER`.
+ */
+export const TASK_STATUS_COMMENT_MARKER = "<!-- coder-factory:task-status -->";
+
+/**
+ * Prepend the marker on its own line, followed by the human-readable content.
+ * The hidden first line is what makes every subsequent edit resolve the same
+ * existing comment via the upsert-by-prefix behavior in
+ * `GitHubClient.commentOnIssue`.
+ */
+export function buildTaskStatusCommentBody(content: string): string {
+	return `${TASK_STATUS_COMMENT_MARKER}\n${content}`;
+}

--- a/src/workflows/wait-for-task-active.test.ts
+++ b/src/workflows/wait-for-task-active.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, test, vi } from "vitest";
+import type { CoderService } from "../services/coder/service";
+import { TaskIdSchema } from "../services/task-runner";
+import { waitForTaskActive } from "./wait-for-task-active";
+
+const taskId = TaskIdSchema.parse("11111111-1111-4111-8111-111111111111");
+
+interface FakeStep {
+	do: ReturnType<typeof vi.fn>;
+	sleep: ReturnType<typeof vi.fn>;
+	calls: string[];
+	sleeps: string[];
+	stepResults: unknown[];
+}
+
+function makeStep(): FakeStep {
+	const calls: string[] = [];
+	const sleeps: string[] = [];
+	const stepResults: unknown[] = [];
+	const fake: FakeStep = {
+		calls,
+		sleeps,
+		stepResults,
+		do: vi.fn(async (name: string, ...rest: unknown[]) => {
+			calls.push(name);
+			const cb = rest[rest.length - 1] as () => Promise<unknown>;
+			const result = await cb();
+			stepResults.push(result);
+			return result;
+		}),
+		sleep: vi.fn(async (name: string, _dur: string) => {
+			sleeps.push(name);
+		}),
+	};
+	return fake;
+}
+
+function makeCoder(statuses: string[]) {
+	let idx = 0;
+	return {
+		getTaskById: vi.fn(async () => {
+			const s = statuses[Math.min(idx, statuses.length - 1)] ?? "unknown";
+			idx++;
+			return {
+				id: taskId,
+				status: s,
+				current_state: null,
+				workspace_id: "ws-1",
+			};
+		}),
+	} as unknown as CoderService;
+}
+
+describe("waitForTaskActive — pre-poll dispatch", () => {
+	test("pre-poll sees active → returns 'active' without entering the loop", async () => {
+		const step = makeStep();
+		const coder = makeCoder(["active"]);
+		const result = await waitForTaskActive({
+			step: step as never,
+			coder,
+			taskId,
+			owner: "o",
+		});
+		expect(result).toBe("active");
+		expect(step.calls).toEqual(["wait-lookup-task"]);
+		expect(step.sleeps).toEqual([]);
+	});
+
+	test("pre-poll sees paused → returns 'error' without entering the loop", async () => {
+		const step = makeStep();
+		const coder = makeCoder(["paused"]);
+		const result = await waitForTaskActive({
+			step: step as never,
+			coder,
+			taskId,
+			owner: "o",
+		});
+		expect(result).toBe("error");
+		expect(step.calls).toEqual(["wait-lookup-task"]);
+		expect(step.sleeps).toEqual([]);
+	});
+
+	test("pre-poll sees unexpected status → returns 'error'", async () => {
+		const step = makeStep();
+		const coder = makeCoder(["weird-new-status"]);
+		const result = await waitForTaskActive({
+			step: step as never,
+			coder,
+			taskId,
+			owner: "o",
+		});
+		expect(result).toBe("error");
+		expect(step.calls).toEqual(["wait-lookup-task"]);
+	});
+});
+
+describe("waitForTaskActive — poll loop", () => {
+	test("pending → active transitions during polling", async () => {
+		const step = makeStep();
+		const coder = makeCoder(["pending", "pending", "initializing", "active"]);
+		const result = await waitForTaskActive({
+			step: step as never,
+			coder,
+			taskId,
+			owner: "o",
+		});
+		expect(result).toBe("active");
+		// 1 pre-poll + 3 loop checks (pending, initializing, active)
+		expect(step.calls).toEqual([
+			"wait-lookup-task",
+			"wait-check-status-1",
+			"wait-check-status-2",
+			"wait-check-status-3",
+		]);
+		// A sleep follows every non-terminal observation (pending, initializing).
+		// The third observation is 'active' → loop returns BEFORE the sleep.
+		expect(step.sleeps).toEqual(["wait-sleep-1", "wait-sleep-2"]);
+	});
+
+	test("returns 'active' when raw.status === 'active' regardless of current_state", async () => {
+		const step = makeStep();
+		const coder = {
+			getTaskById: vi.fn(async () => ({
+				id: taskId,
+				status: "active",
+				current_state: { state: "working" },
+				workspace_id: "ws-1",
+			})),
+		} as unknown as CoderService;
+		const result = await waitForTaskActive({
+			step: step as never,
+			coder,
+			taskId,
+			owner: "o",
+		});
+		expect(result).toBe("active");
+	});
+
+	test("paused observed mid-poll → returns 'error'", async () => {
+		const step = makeStep();
+		const coder = makeCoder(["pending", "paused"]);
+		const result = await waitForTaskActive({
+			step: step as never,
+			coder,
+			taskId,
+			owner: "o",
+		});
+		expect(result).toBe("error");
+	});
+});
+
+describe("waitForTaskActive — error grace window", () => {
+	test("error within grace window, then active → returns 'active'", async () => {
+		const step = makeStep();
+		// Pre-poll 'initializing', then 5 'error', then 'active'. Grace = 10.
+		const coder = makeCoder([
+			"initializing",
+			"error",
+			"error",
+			"error",
+			"error",
+			"error",
+			"active",
+		]);
+		const result = await waitForTaskActive({
+			step: step as never,
+			coder,
+			taskId,
+			owner: "o",
+		});
+		expect(result).toBe("active");
+	});
+
+	test("error persists beyond ERROR_GRACE_ATTEMPTS → returns 'error'", async () => {
+		const step = makeStep();
+		// Pre-poll 'initializing', then infinite 'error'. Grace is 10 attempts.
+		const coder = makeCoder(["initializing", ...Array(30).fill("error")]);
+		const result = await waitForTaskActive({
+			step: step as never,
+			coder,
+			taskId,
+			owner: "o",
+		});
+		expect(result).toBe("error");
+		// Grace ends on attempt=11 → we should NOT have run all 60 iterations.
+		const checkCount = step.calls.filter((n) =>
+			n.startsWith("wait-check-status-"),
+		).length;
+		expect(checkCount).toBeLessThan(60);
+		expect(checkCount).toBeGreaterThanOrEqual(11);
+	});
+
+	test("unknown persists beyond grace → returns 'error'", async () => {
+		const step = makeStep();
+		const coder = makeCoder(["initializing", ...Array(30).fill("unknown")]);
+		const result = await waitForTaskActive({
+			step: step as never,
+			coder,
+			taskId,
+			owner: "o",
+		});
+		expect(result).toBe("error");
+	});
+});
+
+describe("waitForTaskActive — timeout", () => {
+	test("MAX_ATTEMPTS exhausted without reaching active → returns 'error'", async () => {
+		const step = makeStep();
+		// Always 'initializing' — never reaches active, never errors.
+		const coder = makeCoder(Array(100).fill("initializing"));
+		const result = await waitForTaskActive({
+			step: step as never,
+			coder,
+			taskId,
+			owner: "o",
+		});
+		expect(result).toBe("error");
+		// 1 pre-poll + 60 loop checks.
+		const checkCount = step.calls.filter((n) =>
+			n.startsWith("wait-check-status-"),
+		).length;
+		expect(checkCount).toBe(60);
+	});
+});
+
+describe("waitForTaskActive — step naming and projection", () => {
+	test("step names use wait-lookup-task, wait-check-status-{n}, wait-sleep-{n}", async () => {
+		const step = makeStep();
+		const coder = makeCoder(["pending", "pending", "active"]);
+		await waitForTaskActive({
+			step: step as never,
+			coder,
+			taskId,
+			owner: "o",
+		});
+		expect(step.calls[0]).toBe("wait-lookup-task");
+		expect(step.calls[1]).toBe("wait-check-status-1");
+		expect(step.calls[2]).toBe("wait-check-status-2");
+		expect(step.sleeps[0]).toBe("wait-sleep-1");
+	});
+
+	test("step names do not collide with ensureTaskReady's step names", async () => {
+		const step = makeStep();
+		const coder = makeCoder(["pending", "active"]);
+		await waitForTaskActive({
+			step: step as never,
+			coder,
+			taskId,
+			owner: "o",
+		});
+		// ensureTaskReady uses `lookup-task`, `check-status-{n}`, `wait-{n}`.
+		// Ours must NOT match those exact names.
+		expect(step.calls).not.toContain("lookup-task");
+		expect(step.calls).not.toContain("check-status-1");
+		expect(step.sleeps).not.toContain("wait-1");
+	});
+
+	test("step.do callback returns only the scalar {status}", async () => {
+		const step = makeStep();
+		const coder = makeCoder(["active"]);
+		await waitForTaskActive({
+			step: step as never,
+			coder,
+			taskId,
+			owner: "o",
+		});
+		const preResult = step.stepResults[0] as Record<string, unknown>;
+		expect(Object.keys(preResult)).toEqual(["status"]);
+		expect(preResult).toEqual({ status: "active" });
+	});
+
+	test("wraps status reads in step.do with STATUS_RETRY config", async () => {
+		const step = makeStep();
+		const coder = makeCoder(["active"]);
+		await waitForTaskActive({
+			step: step as never,
+			coder,
+			taskId,
+			owner: "o",
+		});
+		// The pre-poll step.do call must include a retry config argument.
+		const firstCall = step.do.mock.calls[0] as unknown[];
+		// Signature: (name, config?, cb). If config is present it's the 2nd arg.
+		expect(firstCall).toHaveLength(3);
+		const config = firstCall[1] as { retries?: { limit?: number } };
+		expect(config?.retries?.limit).toBe(3);
+	});
+
+	test("does NOT throw for any task-state reason (paused/error/timeout)", async () => {
+		const step = makeStep();
+		for (const statuses of [
+			["paused"],
+			["initializing", "paused"],
+			["initializing", ...Array(60).fill("error")],
+			Array(100).fill("pending"),
+		]) {
+			const coder = makeCoder(statuses);
+			await expect(
+				waitForTaskActive({
+					step: step as never,
+					coder,
+					taskId,
+					owner: "o",
+				}),
+			).resolves.toBe("error");
+		}
+	});
+});

--- a/src/workflows/wait-for-task-active.ts
+++ b/src/workflows/wait-for-task-active.ts
@@ -1,0 +1,113 @@
+import type { WorkflowStep, WorkflowStepConfig } from "cloudflare:workers";
+import type { CoderService } from "../services/coder/service";
+import type { TaskId } from "../services/task-runner";
+
+/**
+ * Shared retry policy for cheap idempotent status reads. Mirrors
+ * `ensureTaskReady`'s config so transient network blips are absorbed inside a
+ * single `step.do` rather than bubbling to the instance.
+ */
+const STATUS_RETRY: WorkflowStepConfig = {
+	retries: {
+		limit: 3,
+		delay: "2 seconds",
+		backoff: "exponential",
+	},
+};
+
+// Attempt boundaries at a 30-second constant poll interval.
+// MAX_ATTEMPTS = 60           → ≈ 30 min total budget
+// ERROR_GRACE_ATTEMPTS = 10   → error/unknown beyond attempt 10 → "error" (5 min)
+const MAX_ATTEMPTS = 60;
+const ERROR_GRACE_ATTEMPTS = 10;
+const POLL_INTERVAL = "30 seconds";
+
+export type WaitForTaskActiveResult = "active" | "error";
+
+export interface WaitForTaskActiveOptions {
+	step: WorkflowStep;
+	coder: CoderService;
+	taskId: TaskId;
+	owner: string;
+}
+
+/**
+ * Wait for the raw Coder task status to reach `"active"` OR a terminal error.
+ *
+ * Looser than `ensureTaskReady`: we only care about `status === "active"` and
+ * do NOT inspect `current_state`. Intended for post-create sandbox-boot
+ * polling where the caller wants to surface "running" vs "failed" to the user
+ * ASAP, without waiting for the agent to settle into idle.
+ *
+ * Returns:
+ *  - `"active"` on first observation of `status === "active"`.
+ *  - `"error"` when `status` is `error`/`unknown` past `ERROR_GRACE_ATTEMPTS`,
+ *    when `paused` is observed, when the status is an unexpected value, or
+ *    when the `MAX_ATTEMPTS` budget is exhausted.
+ *
+ * Never throws for task-state reasons. Transient network errors inside a
+ * single `step.do` are absorbed by `STATUS_RETRY`; if those retries are
+ * exhausted the instance errors per standard Workflow semantics.
+ *
+ * Step naming is distinct from `ensureTaskReady` (`wait-lookup-task`,
+ * `wait-check-status-${n}`, `wait-sleep-${n}`) so both helpers can compose in
+ * one instance without cache collisions.
+ */
+export async function waitForTaskActive(
+	opts: WaitForTaskActiveOptions,
+): Promise<WaitForTaskActiveResult> {
+	const { step, coder, taskId, owner } = opts;
+
+	const initial = await step.do("wait-lookup-task", STATUS_RETRY, async () => {
+		const raw = await coder.getTaskById(taskId, owner);
+		return { status: raw.status };
+	});
+
+	const preResult = classify(initial.status, 0);
+	if (preResult === "active") return "active";
+	if (preResult === "error") return "error";
+
+	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+		const obs = await step.do(
+			`wait-check-status-${attempt}`,
+			STATUS_RETRY,
+			async () => {
+				const raw = await coder.getTaskById(taskId, owner);
+				return { status: raw.status };
+			},
+		);
+
+		const result = classify(obs.status, attempt);
+		if (result === "active") return "active";
+		if (result === "error") return "error";
+
+		await step.sleep(`wait-sleep-${attempt}`, POLL_INTERVAL);
+	}
+
+	return "error";
+}
+
+/**
+ * Map an observed raw status to a terminal result, "continue" to keep polling,
+ * or "error" when the error-grace window is exhausted. Pure function of the
+ * observation and the attempt counter — safe to call across replays.
+ */
+function classify(
+	status: string,
+	attempt: number,
+): WaitForTaskActiveResult | "continue" {
+	switch (status) {
+		case "active":
+			return "active";
+		case "pending":
+		case "initializing":
+			return "continue";
+		case "error":
+		case "unknown":
+			return attempt > ERROR_GRACE_ATTEMPTS ? "error" : "continue";
+		case "paused":
+			return "error";
+		default:
+			return "error";
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/106

## Summary

- After posting the initial `Task created` comment, `runCreateTask` now polls the new Coder task until raw `status === "active"` (sandbox has booted) or a terminal error, then edits the existing issue comment in place with `Task is running: …` or `Failed to create task sandbox: …`.
- New helper `src/workflows/wait-for-task-active.ts` implements this loose-semantics poll. Unlike `ensureTaskReady`, it inspects only `status` — not `current_state` — so the user gets a running/failed signal as soon as the sandbox is up.
- New module `src/workflows/task-status-comment.ts` exports a shared `TASK_STATUS_COMMENT_MARKER` (hidden HTML comment) and `buildTaskStatusCommentBody`. All three writers (`create-task` initial, `create-task` update, `close-task`) now share the same marker as their first line, so `GitHubClient.commentOnIssue`'s upsert-by-prefix keeps editing the same comment regardless of the visible body each writer chose.
- `react-to-comment` in `runComment` is moved to fire immediately after `locate-task` and before `ensureTaskReady`, so the eyes reaction lands without waiting on poll latency.

## Implementation notes

- `waitForTaskActive` step names are distinct from `ensureTaskReady`'s (`wait-lookup-task`, `wait-check-status-${n}`, `wait-sleep-${n}`) so the two can compose in one instance without cache collisions.
- Thresholds mirror `ensureTaskReady` (`MAX_ATTEMPTS = 60`, `ERROR_GRACE_ATTEMPTS = 10`, 30s poll, `STATUS_RETRY` 3×2s exp).
- Step callbacks return only `{ status }` — narrow scalar projection per `src/workflows/AGENTS.md`.
- `waitForTaskActive` never throws for task-state reasons; terminal cases (paused, error beyond grace, timeout, unexpected status) return `"error"` so the create flow can report "Failed to create task sandbox" rather than erroring the instance.

## Test plan

- [x] `npm run check` (typecheck + lint + format + 269 tests) passes
- [x] New `wait-for-task-active.test.ts` covers EARS 1-10: pre-poll active, pending→active, active with non-idle state, paused mid-poll, error within/beyond grace, unknown-beyond-grace, timeout, step naming, distinct-from-ensureTaskReady, scalar projection, STATUS_RETRY config, never-throws invariant
- [x] New `task-status-comment.test.ts` covers the marker builder
- [x] Updated `create-task.test.ts` asserts the new step order, scalar projection (now with `taskId`), active/error message bodies, and that every `commentOnIssue` call uses `TASK_STATUS_COMMENT_MARKER`
- [x] Updated `close-task.test.ts` asserts shared marker usage
- [x] Updated `comment.test.ts` asserts reaction fires before `ensureTaskReady`
- [x] Updated `task-runner-workflow.test.ts` and `e2e.test.ts` with the new `wait-lookup-task` and `update-status-comment` step mocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wait for sandbox boot after task creation and update issue comment with status
> - Adds [`waitForTaskActive`](https://github.com/xmtplabs/coder-action/pull/107/files#diff-44020519e8442a285820751be012f1386490e2d3e03cf6fee05aaf25e03ca8eb), a polling helper that reads raw task status until it reaches `active`, an error condition, or a timeout, returning `"active"` or `"error"` without throwing.
> - After creating a task, [`runCreateTask`](https://github.com/xmtplabs/coder-action/pull/107/files#diff-192857ed4591c9d424790cf409e98f38d1e616226a3e5107fe118f18e8ec2761) now blocks on `waitForTaskActive` and then posts or updates a GitHub issue comment indicating "Task is running" or "Failed to create task sandbox".
> - Adds [`task-status-comment`](https://github.com/xmtplabs/coder-action/pull/107/files#diff-1b46c5edc7c03d618d6f6498a856ffd54cc769715108a70d277c81252e1c99e8) with a shared hidden HTML marker constant and a body builder so all status comments are upserted by the same prefix.
> - Moves the react-to-comment step in [`runComment`](https://github.com/xmtplabs/coder-action/pull/107/files#diff-0c08f09e7258d354d2d24d03cbd71ee3f838c8ba9e9eb1195fd8fb9d19ac51f5) to fire before `ensureTaskReady` and `send-task-input`.
> - Updates [`runCloseTask`](https://github.com/xmtplabs/coder-action/pull/107/files#diff-1b2024c4780a9b38be8694864e4bc805d55f06d2e687d07ca5d5611d026d0329) to use the marker-based comment body and match prefix instead of the previous `"Task created:"` prefix.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e74e612.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->