### PR TITLE
Add Zed editor settings configured for Biome

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,31 @@
+{
+	"languages": {
+		"TypeScript": {
+			"formatter": { "language_server": { "name": "biome" } },
+			"code_actions_on_format": {
+				"source.fixAll.biome": true,
+				"source.organizeImports.biome": true
+			}
+		},
+		"TSX": {
+			"formatter": { "language_server": { "name": "biome" } },
+			"code_actions_on_format": {
+				"source.fixAll.biome": true,
+				"source.organizeImports.biome": true
+			}
+		},
+		"JavaScript": {
+			"formatter": { "language_server": { "name": "biome" } },
+			"code_actions_on_format": {
+				"source.fixAll.biome": true,
+				"source.organizeImports.biome": true
+			}
+		},
+		"JSON": {
+			"formatter": { "language_server": { "name": "biome" } }
+		},
+		"JSONC": {
+			"formatter": { "language_server": { "name": "biome" } }
+		}
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/109

## Summary

Adds `.zed/settings.json` so Zed uses the Biome language server for formatting and code actions, matching the project's existing `biome.json` setup.

## Details

- Per-language `formatter.language_server: biome` for TypeScript, TSX, JavaScript, JSON, and JSONC — the languages this repo actually contains (TS source in `src/**/*.ts`, JSON configs like `biome.json`, `package.json`, `tsconfig.json`, `wrangler.toml`'s neighbours).
- `code_actions_on_format` enables `source.fixAll.biome` and `source.organizeImports.biome` for TypeScript, TSX, and JavaScript on save.
- Follows Biome's Zed guidance (https://biomejs.dev/reference/zed/) of setting Biome per-language rather than at the top level to avoid conflicts with unsupported languages.

Zed users must install the Biome extension from Zed's extensions view for the language server to be available.

## Test plan

- [x] `npm run check` (typecheck + lint + format:check + 269 vitest tests) — pass
- [ ] Open the repo in Zed with the Biome extension installed; confirm format-on-save uses Biome and `organizeImports` runs on TS files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Zed editor settings to use Biome as formatter for JS, TS, and JSON
> Adds [.zed/settings.json](https://github.com/xmtplabs/coder-action/pull/110/files#diff-abb804d570c3104a261c81b34f0ad1c1d5edb2f62e1318fa5030dbe6ffbdf3d4) configuring Biome as the formatter for TypeScript, TSX, JavaScript, JSON, and JSONC. For TypeScript, TSX, and JavaScript, also enables `source.fixAll.biome` and `source.organizeImports.biome` as code actions on format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab49e14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->