### PR TITLE
Handle missing task in comment workflow as no-op

### DIFF
--- a/src/workflows/steps/comment.test.ts
+++ b/src/workflows/steps/comment.test.ts
@@ -255,24 +255,45 @@ describe("runComment — task-name derivation (regression guard)", () => {
 // ── Task-not-found + structured-message coverage ─────────────────────────────
 
 describe("runComment — error paths + message formatting", () => {
-	test("throws NonRetryableError when task not found (PR path)", async () => {
-		const { NonRetryableError } = await import("cloudflare:workflows");
+	test("PR comment with no matching task → silent short-circuit (no throw, no send)", async () => {
+		// Previously this path threw NonRetryableError, which surfaced the
+		// instance as `errored` in workflow listings even though a comment on
+		// an issue/PR without an associated Coder task is benign.
 		const step = makeStep();
 		const coder = makeCoder({ findTaskByName: vi.fn(async () => null) });
 		const github = makeGithub();
 
-		await expect(
-			runComment({
-				step: step as never,
-				coder: coder as never,
-				github: github as never,
-				config,
-				event: commentEvent("pull_request"),
-			}),
-			// Assert the specific error type so a regression that throws a
-			// generic Error (and thus gets retried by the engine instead of
-			// terminating the instance) fails this test.
-		).rejects.toThrowError(NonRetryableError);
+		await runComment({
+			step: step as never,
+			coder: coder as never,
+			github: github as never,
+			config,
+			event: commentEvent("pull_request"),
+		});
+
+		expect(step.calls).toEqual(["find-linked-issues", "locate-task"]);
+		expect(coder.sendTaskInput).not.toHaveBeenCalled();
+		expect(github.addReactionToComment).not.toHaveBeenCalled();
+		expect(github.addReactionToReviewComment).not.toHaveBeenCalled();
+	});
+
+	test("issue comment with no matching task → silent short-circuit (no throw, no send)", async () => {
+		const step = makeStep();
+		const coder = makeCoder({ findTaskByName: vi.fn(async () => null) });
+		const github = makeGithub();
+
+		await runComment({
+			step: step as never,
+			coder: coder as never,
+			github: github as never,
+			config,
+			event: commentEvent("issue"),
+		});
+
+		expect(step.calls).toEqual(["locate-task"]);
+		expect(coder.sendTaskInput).not.toHaveBeenCalled();
+		expect(github.addReactionToComment).not.toHaveBeenCalled();
+		expect(github.addReactionToReviewComment).not.toHaveBeenCalled();
 	});
 
 	test("PR review comment: sendTaskInput receives structured formatPRCommentMessage with file:line", async () => {

--- a/src/workflows/steps/comment.ts
+++ b/src/workflows/steps/comment.ts
@@ -70,9 +70,9 @@ async function resolveIssueNumber(
  * Workflow step factory for `comment_posted` (both PR and issue kinds).
  *
  * Flow: [find-linked-issues for PR comments] → locate-task → ensureTaskReady
- * → send-task-input → react-to-comment. Throws `NonRetryableError` if the
- * task doesn't exist — there's nothing to send to, and retrying won't create
- * it.
+ * → send-task-input → react-to-comment. Silently short-circuits when no task
+ * exists for the issue — a comment on an unassigned issue/PR is benign and
+ * shouldn't surface the workflow instance as `errored`.
  *
  * The task input is wrapped in the same `[INSTRUCTIONS]` / `[COMMENT]` template
  * the pre-migration action classes used (`formatPRCommentMessage` /
@@ -96,23 +96,31 @@ export async function runComment(ctx: RunCommentContext): Promise<void> {
 		issueNumber,
 	);
 
-	const located = await step.do("locate-task", async () => {
-		const raw = await coder.findTaskByName(taskName);
-		if (!raw) {
-			throw new NonRetryableError(`task ${taskName} not found`);
-		}
-		// `findTaskByName` returns `ExperimentalCoderSDKTask | null` (narrowed via
-		// Zod inside CoderService). Validate the scalar fields we depend on before
-		// projecting into the step return — defensive against upstream SDK shape
-		// changes.
-		const task = raw as unknown as { id?: unknown; owner_id?: unknown };
-		if (typeof task.id !== "string" || typeof task.owner_id !== "string") {
-			throw new NonRetryableError(
-				`locate-task: task ${taskName} missing id/owner_id scalars`,
-			);
-		}
-		return { taskId: task.id, owner: task.owner_id };
-	});
+	const located = await step.do<{ taskId: string; owner: string } | null>(
+		"locate-task",
+		async () => {
+			const raw = await coder.findTaskByName(taskName);
+			// No task exists for this issue/PR — a comment without an associated
+			// Coder task is benign (e.g. a comment on an issue that was never
+			// assigned to the agent). Short-circuit silently, matching
+			// `failed-check.ts`'s behavior for the same case.
+			if (!raw) {
+				return null;
+			}
+			// `findTaskByName` returns `ExperimentalCoderSDKTask | null` (narrowed via
+			// Zod inside CoderService). Validate the scalar fields we depend on before
+			// projecting into the step return — defensive against upstream SDK shape
+			// changes.
+			const task = raw as unknown as { id?: unknown; owner_id?: unknown };
+			if (typeof task.id !== "string" || typeof task.owner_id !== "string") {
+				throw new NonRetryableError(
+					`locate-task: task ${taskName} missing id/owner_id scalars`,
+				);
+			}
+			return { taskId: task.id, owner: task.owner_id };
+		},
+	);
+	if (located == null) return;
 
 	const taskId = TaskIdSchema.parse(located.taskId);
 


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/116

## Summary

When a comment is posted on an issue or PR with no associated Coder task, `runComment` previously threw `NonRetryableError` from the `locate-task` step. That transitioned the workflow instance to `errored` state — visible in `wrangler workflows instances list` and Workers Logs as a failure — even though the situation is benign (e.g. a comment on an issue that was never assigned to the agent).

## Changes

- `src/workflows/steps/comment.ts`: `locate-task` returns `null` when `findTaskByName` returns `null`. `runComment` checks for this and returns early, silently matching the existing "PR comment with no linked issue" short-circuit. The same pattern is already used in `src/workflows/steps/failed-check.ts`.
- Malformed SDK shapes (present task but missing `id`/`owner_id` scalars) still throw `NonRetryableError` — that failure mode is distinct and should remain loud.
- `src/workflows/steps/comment.test.ts`: replaced the "throws NonRetryableError when task not found (PR path)" test with two tests covering silent short-circuit on both PR and issue paths.

## Test plan

- [x] `npm run check` passes locally (typecheck + lint + format + 374 vitest tests).
- [x] New tests assert `step.calls` ends at `locate-task` with no reaction, no `send-task-input`, and no thrown error.
- [x] Regression coverage for the happy path and the malformed-SDK path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle missing task in comment workflow as a silent no-op instead of throwing
> When `runComment` cannot find a task for an issue or PR, the `locate-task` step now returns `null` and the workflow exits early instead of throwing a `NonRetryableError`. No task input is sent and no GitHub reactions are added.
>
> - Behavioral Change: previously a missing task caused a `NonRetryableError`; it now silently short-circuits with no error and no side effects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50c156e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->