### PR TITLE
Use issue number (not issue ID) in task prompt text

### DIFF
--- a/src/workflows/steps/create-task.test.ts
+++ b/src/workflows/steps/create-task.test.ts
@@ -362,7 +362,7 @@ describe("runCreateTask", () => {
 				"ISSUE_URL: https://github.com/acme/repo/issues/42",
 				"REPO_OWNER: acme",
 				"REPO_NAME: repo",
-				"ISSUE_ID: 987654",
+				"ISSUE_NUMBER: 42",
 				"",
 				"Use the /coder-task skill to resolve the issue",
 				"",

--- a/src/workflows/steps/create-task.ts
+++ b/src/workflows/steps/create-task.ts
@@ -81,7 +81,7 @@ export async function runCreateTask(ctx: RunCreateTaskContext): Promise<void> {
 				prompt: JSON.stringify(
 					buildTemplateInputs({
 						repository: event.repository,
-						issue: { id: event.issue.id, url: event.issue.url },
+						issue: { number: event.issue.number, url: event.issue.url },
 						settings: repoConfig.settings,
 					}),
 				),

--- a/src/workflows/steps/template-inputs.ts
+++ b/src/workflows/steps/template-inputs.ts
@@ -24,7 +24,7 @@ export type TemplateInputs = z.infer<typeof TemplateInputsSchema>;
 
 export interface BuildTemplateInputsParams {
 	repository: { owner: string; name: string };
-	issue: { id: number; url: string };
+	issue: { number: number; url: string };
 	settings: RepoConfigSettings;
 }
 
@@ -37,12 +37,12 @@ function buildAiPrompt(params: {
 	issueUrl: string;
 	repoOwner: string;
 	repoName: string;
-	issueId: number;
+	issueNumber: number;
 }): string {
 	return `ISSUE_URL: ${params.issueUrl}
 REPO_OWNER: ${params.repoOwner}
 REPO_NAME: ${params.repoName}
-ISSUE_ID: ${params.issueId}
+ISSUE_NUMBER: ${params.issueNumber}
 
 Use the /coder-task skill to resolve the issue
 `;
@@ -64,7 +64,7 @@ export function buildTemplateInputs(
 			issueUrl: issue.url,
 			repoOwner: repository.owner,
 			repoName: repository.name,
-			issueId: issue.id,
+			issueNumber: issue.number,
 		}),
 		ai_provider: settings.harness.provider,
 		...(volumes.length > 0 ? { extra_volumes: volumes } : {}),


### PR DESCRIPTION
## Summary

- Swap `issue.id` → `issue.number` in the `ai_prompt` block produced by `buildTemplateInputs`.
- Rename the label from `ISSUE_ID:` to `ISSUE_NUMBER:` so the downstream `/coder-task` skill receives the user-facing issue number.
- Update the `create-task.test.ts` fixture assertion to expect `ISSUE_NUMBER: 42`.

Resolves https://github.com/xmtplabs/coder-action/issues/117

## Test plan

- [x] `npm run check` (typecheck + lint + format + 373 tests) passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace issue ID with issue number in AI task prompt text
> Changes the `buildAiPrompt` function in [`template-inputs.ts`](https://github.com/xmtplabs/coder-action/pull/119/files#diff-0aacba3ca4f48f9a81461bd5c4b407baf41028b815bd1daa6715909a1dadde22) to use `issue.number` instead of `issue.id`, renaming the prompt field from `ISSUE_ID` to `ISSUE_NUMBER`. The `BuildTemplateInputsParams` interface and `create-task.ts` are updated to match. Behavioral Change: generated `ai_prompt` strings now contain `ISSUE_NUMBER: <number>` instead of `ISSUE_ID: <id>`, which are different values since GitHub issue numbers and internal IDs are not the same.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d124265.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->