### PR TITLE
Store empty RepoConfig when config.toml is absent

### DIFF
--- a/src/workflows/repo-config-workflow.test.ts
+++ b/src/workflows/repo-config-workflow.test.ts
@@ -56,7 +56,7 @@ describe("RepoConfigWorkflow dispatch — happy path", () => {
 });
 
 describe("RepoConfigWorkflow dispatch — file absent", () => {
-	test("present=false → early return, no DO write, complete", async () => {
+	test("present=false → skips parse, still writes empty settings, complete", async () => {
 		const instanceId = "config_push-repo-missing-delivery-2";
 		await using instance = await introspectWorkflowInstance(
 			env.REPO_CONFIG_WORKFLOW,
@@ -64,9 +64,10 @@ describe("RepoConfigWorkflow dispatch — file absent", () => {
 		);
 		await instance.modify(async (m) => {
 			await m.mockStepResult({ name: "fetch-config-file" }, { present: false });
-			// parse-and-validate / store-repo-config intentionally NOT mocked — if
-			// the workflow tried to run them unmocked it would fail, exposing a
-			// regression in the early-exit branch.
+			// parse-and-validate intentionally NOT mocked — if the workflow tried
+			// to run it when the file is absent, the unmocked step would fail and
+			// expose a regression in the skip-parse branch.
+			await m.mockStepResult({ name: "store-repo-config" }, { ok: true });
 		});
 		await env.REPO_CONFIG_WORKFLOW.create({ id: instanceId, params: base });
 		await expect(instance.waitForStatus("complete")).resolves.not.toThrow();

--- a/src/workflows/steps/sync-repo-config.test.ts
+++ b/src/workflows/steps/sync-repo-config.test.ts
@@ -111,7 +111,7 @@ describe("runSyncRepoConfig", () => {
 		});
 	});
 
-	test("file absent — only runs fetch-config-file and makes no DO writes", async () => {
+	test("file absent — skips parse-and-validate and writes empty settings to DO", async () => {
 		const { step, calls } = makeStep();
 		const { REPO_CONFIG_DO, idFromName, get, setRepoConfig } = makeDO();
 		const github = {
@@ -127,10 +127,18 @@ describe("runSyncRepoConfig", () => {
 			logger: noopLogger,
 		});
 
-		expect(calls.map((c) => c.name)).toEqual(["fetch-config-file"]);
-		expect(idFromName).not.toHaveBeenCalled();
-		expect(get).not.toHaveBeenCalled();
-		expect(setRepoConfig).not.toHaveBeenCalled();
+		expect(calls.map((c) => c.name)).toEqual([
+			"fetch-config-file",
+			"store-repo-config",
+		]);
+		expect(idFromName).toHaveBeenCalledWith("acme/repo");
+		expect(get).toHaveBeenCalledTimes(1);
+		expect(setRepoConfig).toHaveBeenCalledWith({
+			repositoryId: 42,
+			repositoryFullName: "acme/repo",
+			installationId: 100,
+			settings: {},
+		});
 	});
 
 	test("TOML syntax invalid — parse-and-validate throws; store-repo-config not invoked", async () => {

--- a/src/workflows/steps/sync-repo-config.ts
+++ b/src/workflows/steps/sync-repo-config.ts
@@ -49,21 +49,25 @@ export async function runSyncRepoConfig(
 		return { present: true as const, contentBase64: res.contentBase64 };
 	});
 
-	if (!fileResult.present) {
-		logger.info("No repo config file present; skipping DO write", {
+	let settings: StoredRepoConfig["settings"];
+	if (fileResult.present) {
+		const parseResult = await step.do("parse-and-validate", async () => {
+			const raw = Buffer.from(fileResult.contentBase64, "base64").toString(
+				"utf8",
+			);
+			return { settings: parseRepoConfigToml(raw) };
+		});
+		settings = parseResult.settings;
+	} else {
+		// No config file at head SHA: persist empty settings so downstream
+		// `getRepoConfig()` returns a defaulted `RepoConfig` instead of `null`,
+		// which would otherwise push the task onto the legacy template path.
+		logger.info("No repo config file present; storing empty settings", {
 			fullName,
 			sha: event.head.sha,
 		});
-		return;
+		settings = {};
 	}
-
-	const parseResult = await step.do("parse-and-validate", async () => {
-		const raw = Buffer.from(fileResult.contentBase64, "base64").toString(
-			"utf8",
-		);
-		const settings = parseRepoConfigToml(raw);
-		return { settings };
-	});
 
 	await step.do("store-repo-config", async () => {
 		const id = env.REPO_CONFIG_DO.idFromName(fullName);
@@ -72,7 +76,7 @@ export async function runSyncRepoConfig(
 			repositoryId,
 			repositoryFullName: fullName,
 			installationId,
-			settings: parseResult.settings,
+			settings,
 		};
 		await stub.setRepoConfig(cfg);
 		return { ok: true as const };


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/120

## Summary

When a push to the default branch arrives for a repo that does not have `.code-factory/config.toml`, `runSyncRepoConfig` was skipping the `RepoConfigDO` write entirely. Downstream, `getRepoConfig()` then returned `null`, and `runCreateTask` fell back to the legacy URL-as-prompt template path — so repos without a config file never reached the new `code-factory` template.

This change writes an empty settings record (`settings: {}`) to the DO when the file is absent. `resolveRepoConfigSettings({})` applies all defaults, so `getRepoConfig()` now returns a fully-populated `RepoConfig` (`sandbox.size="medium"`, `sandbox.docker=false`, `sandbox.volumes=[]`, `harness.provider="claude_code"`, `scheduled_jobs=[]`), and the task-creation path naturally uses the new template.

## Changes

- `src/workflows/steps/sync-repo-config.ts` — when `fetch-config-file` reports `present: false`, skip `parse-and-validate` and fall through to `store-repo-config` with `settings: {}`.
- `src/workflows/steps/sync-repo-config.test.ts` — update the "file absent" unit test to assert that `setRepoConfig` is called with empty settings and that `parse-and-validate` is not called.
- `src/workflows/repo-config-workflow.test.ts` — mock `store-repo-config` in the file-absent dispatch test.

## Unchanged behavior

- File-present happy path (fetch → parse → store) is untouched.
- Invalid TOML / Zod failures on a present file still throw `NonRetryableError` from `parse-and-validate`.
- Non-default-branch pushes are still skipped at `routePush`.
- `RepoConfigDO`, schema module, and template-selection logic are unchanged.

## Test plan

- [x] `npm test` — 374 passed
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Store empty RepoConfig settings when `config.toml` is absent
> Previously, `runSyncRepoConfig` returned early without writing to the Durable Object when the config file was missing. Now it always writes an envelope with empty settings (`{}`) to the DO via `setRepoConfig`, skipping only the parse-and-validate step.
>
> Behavioral Change: repos with no `config.toml` will now have an empty settings record written to the DO on each sync, where previously no write occurred.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76fbf32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->