### PR TITLE
feat(config): add on_event.failed_run, serve JSON schema, and publish repo config reference

### DIFF
--- a/.code-factory/config.toml
+++ b/.code-factory/config.toml
@@ -1,3 +1,5 @@
+#:schema https://task-action.xmtp.team/schema.json
+
 [sandbox]
 size = "small"
 docker = false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,3 +111,4 @@ Cross-cutting:
 
 - [GitHub App setup](docs/github-app-setup.md) — registration, installation, secrets
 - [Coder API endpoints](docs/coder-api.md) — experimental tasks + stable endpoints we consume
+- [Per-repo config format](docs/repo-config.md) — `.code-factory/config.toml` field reference for sandbox, harness, scheduled jobs, and event hooks

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ All non-secret config lives in [`wrangler.toml`](wrangler.toml) under `[vars]`. 
 | `CODER_ORGANIZATION` | var | Coder organization (default: `default`) |
 | `LOG_FORMAT` | var | `json` (production) or `pretty` (local dev) |
 
+### Per-repo configuration
+
+Consuming repositories may define a `.code-factory/config.toml` file to customize sandbox sizing, harness selection, scheduled jobs, and event hooks. See [docs/repo-config.md](docs/repo-config.md) for the full reference. A machine-readable JSON Schema is served at `/schema.json` for editor integration (Taplo, VS Code).
+
 ## Running
 
 ```bash

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
 	"files": {
 		"includes": ["src/**/*.ts", "*.json", "*.md"],
 		"maxSize": 2097152

--- a/docs/repo-config.md
+++ b/docs/repo-config.md
@@ -1,0 +1,108 @@
+# Repo Config (`.code-factory/config.toml`)
+
+## Overview
+
+Each repository that uses coder-action may include an optional `.code-factory/config.toml` file at the repository root. The file uses standard TOML syntax. Unknown keys are silently stripped (Zod `.strip()` behavior), so repositories can land forward-compatible config before the server knows about a new field. Validation runs on the write path via `parseRepoConfigToml` whenever a config push event is processed.
+
+## Editor integration
+
+Point [Taplo](https://taplo.tamasfe.dev/) or the VS Code TOML extension at the served `/schema.json` endpoint to get hover docs and inline validation.
+
+Top-of-file directive (no extra tooling required):
+
+```toml
+#:schema https://<your-worker-host>/schema.json
+```
+
+Or add a `.taplo.toml` file at the repository root:
+
+```toml
+[schema]
+path = "https://<your-worker-host>/schema.json"
+include = [".code-factory/config.toml"]
+```
+
+The schema is generated from the fully resolved Zod shape in input mode, so `default` values are visible in editor hover tooltips.
+
+## `[sandbox]`
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `size` | `"small"` \| `"medium"` \| `"large"` | `"medium"` | No | Controls sandbox instance sizing. |
+| `docker` | boolean | `false` | No | Enables docker-in-docker inside the sandbox. |
+| `volumes` | array of `[[sandbox.volumes]]` | `[]` | No | Persistent volumes attached to the sandbox. |
+
+## `[[sandbox.volumes]]`
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `path` | string | — | Yes | Mount point inside the sandbox. |
+| `size` | volume-size string | `"10Gi"` | No | Accepts common variants (`10gb`, `10GB`, `10G`, `10gi`, `10Gi`) and is always normalized to the canonical binary-SI form (`10Gi`, `500Mi`, `2Ti`, `64Ki`). Supports K/M/G/T prefixes. |
+
+## `[harness]`
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `provider` | `"claude_code"` \| `"codex"` | `"claude_code"` | No | Selects the code-agent harness. |
+
+## `[[scheduled_jobs]]`
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `name` | string | — | Yes | Display name for the scheduled job. |
+| `branch` | string | — | Yes | Branch the job runs against. |
+| `schedule` | string | — | Yes | Cron expression (e.g. `"0 9 * * 1"`). |
+| `prompt` | string | — | Yes | Prompt forwarded to the agent when the job fires. |
+
+## `[[on_event.failed_run]]`
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `workflows` | array of strings | — | Yes | Workflow names (as they appear in GitHub Actions) to watch. Must be non-empty. |
+| `branches` | array of strings | — | Yes | Branches on which a failed `workflow_run` triggers this event. Must be non-empty. |
+| `prompt_additions` | string | — | No | Extra prompt context forwarded to the task. |
+
+**Schema-only in this release — no consumer yet.** The block validates today; event dispatch is a future change.
+
+## Examples
+
+Minimal config (sandbox defaults apply):
+
+```toml
+[sandbox]
+size = "large"
+```
+
+Full config (every section populated):
+
+```toml
+[sandbox]
+size = "large"
+docker = true
+
+[[sandbox.volumes]]
+path = "/home/user/data"
+size = "20Gi"
+
+[[sandbox.volumes]]
+path = "/tmp/cache"
+size = "5Gi"
+
+[harness]
+provider = "claude_code"
+
+[[scheduled_jobs]]
+name = "weekly-audit"
+branch = "main"
+schedule = "0 9 * * 1"
+prompt = "Run the dependency audit and open a PR with any updates."
+
+[[on_event.failed_run]]
+workflows = ["ci.yml", "deploy.yml"]
+branches = ["main", "release"]
+prompt_additions = "Focus on the failing step and propose a fix."
+```
+
+## JSON Schema
+
+The Worker serves the JSON Schema at `GET /schema.json`. The schema reflects the latest deploy of the Worker and is generated directly from the Zod validation shape, so it always matches what `parseRepoConfigToml` accepts. Use the endpoint URL in Taplo or VS Code as shown in the Editor integration section above.

--- a/docs/repo-config.md
+++ b/docs/repo-config.md
@@ -11,14 +11,14 @@ Point [Taplo](https://taplo.tamasfe.dev/) or the VS Code TOML extension at the s
 Top-of-file directive (no extra tooling required):
 
 ```toml
-#:schema https://<your-worker-host>/schema.json
+#:schema https://task-action.xmtp.team/schema.json
 ```
 
 Or add a `.taplo.toml` file at the repository root:
 
 ```toml
 [schema]
-path = "https://<your-worker-host>/schema.json"
+path = "https://task-action.xmtp.team/schema.json"
 include = [".code-factory/config.toml"]
 ```
 

--- a/src/config/repo-config-schema.test.ts
+++ b/src/config/repo-config-schema.test.ts
@@ -119,6 +119,106 @@ describe("resolveRepoConfigSettings — defaults applied on read", () => {
 	});
 });
 
+describe("parseRepoConfigToml — on_event.failed_run", () => {
+	test("full entry with all fields → parses", () => {
+		const toml = `
+[[on_event.failed_run]]
+workflows = ["CI"]
+branches = ["main"]
+prompt_additions = "There was a failed run. Fix it"
+`;
+		const parsed = parseRepoConfigToml(toml);
+		expect(parsed.on_event?.failed_run?.[0]).toEqual({
+			workflows: ["CI"],
+			branches: ["main"],
+			prompt_additions: "There was a failed run. Fix it",
+		});
+	});
+
+	test("entry without prompt_additions → parses", () => {
+		const toml = `
+[[on_event.failed_run]]
+workflows = ["CI"]
+branches = ["main"]
+`;
+		const parsed = parseRepoConfigToml(toml);
+		expect(parsed.on_event?.failed_run?.[0]).toEqual({
+			workflows: ["CI"],
+			branches: ["main"],
+		});
+	});
+
+	test("multiple entries → preserved in order", () => {
+		const toml = `
+[[on_event.failed_run]]
+workflows = ["CI"]
+branches = ["main"]
+
+[[on_event.failed_run]]
+workflows = ["Deploy"]
+branches = ["release"]
+`;
+		const parsed = parseRepoConfigToml(toml);
+		expect(parsed.on_event?.failed_run?.map((e) => e.workflows[0])).toEqual([
+			"CI",
+			"Deploy",
+		]);
+	});
+
+	test("unknown keys inside entry are dropped", () => {
+		const toml = `
+[[on_event.failed_run]]
+workflows = ["CI"]
+branches = ["main"]
+future_field = "ignored"
+`;
+		const parsed = parseRepoConfigToml(toml);
+		expect(parsed.on_event?.failed_run?.[0]).toEqual({
+			workflows: ["CI"],
+			branches: ["main"],
+		});
+	});
+
+	test("missing workflows → NonRetryableError", () => {
+		expect(() =>
+			parseRepoConfigToml(`[[on_event.failed_run]]\nbranches = ["main"]`),
+		).toThrow(/Invalid RepoConfig/);
+	});
+
+	test("empty workflows array → NonRetryableError", () => {
+		expect(() =>
+			parseRepoConfigToml(
+				`[[on_event.failed_run]]\nworkflows = []\nbranches = ["main"]`,
+			),
+		).toThrow(/Invalid RepoConfig/);
+	});
+
+	test("missing branches → NonRetryableError", () => {
+		expect(() =>
+			parseRepoConfigToml(`[[on_event.failed_run]]\nworkflows = ["CI"]`),
+		).toThrow(/Invalid RepoConfig/);
+	});
+
+	test("empty branches array → NonRetryableError", () => {
+		expect(() =>
+			parseRepoConfigToml(
+				`[[on_event.failed_run]]\nworkflows = ["CI"]\nbranches = []`,
+			),
+		).toThrow(/Invalid RepoConfig/);
+	});
+
+	test("error message does not leak raw workflow/branch values", () => {
+		try {
+			parseRepoConfigToml(
+				`[[on_event.failed_run]]\nworkflows = ["SECRET_WORKFLOW"]`,
+				// missing branches — triggers validation error
+			);
+		} catch (err) {
+			expect((err as Error).message).not.toContain("SECRET_WORKFLOW");
+		}
+	});
+});
+
 describe("volume size normalization → canonical Kubernetes binary-SI form", () => {
 	test.each([
 		["10gb", "10Gi"],

--- a/src/config/repo-config-schema.test.ts
+++ b/src/config/repo-config-schema.test.ts
@@ -308,6 +308,9 @@ describe("volume size normalization → canonical Kubernetes binary-SI form", ()
 });
 
 describe("JSON_SCHEMA export", () => {
+	// biome-ignore lint/suspicious/noExplicitAny: JSON Schema traversal — recursive unknown shape
+	const schemaAny = JSON_SCHEMA as any;
+
 	test("has required top-level metadata", () => {
 		expect(JSON_SCHEMA.$schema).toBe(
 			"https://json-schema.org/draft/2020-12/schema",
@@ -318,33 +321,33 @@ describe("JSON_SCHEMA export", () => {
 	});
 
 	test("sandbox.size has default 'medium' and is optional", () => {
-		const s = JSON_SCHEMA as any;
+		const s = schemaAny;
 		const sandbox = s.properties.sandbox;
 		expect(sandbox.properties.size.default).toBe("medium");
 		expect(sandbox.required ?? []).not.toContain("size");
 	});
 
 	test("sandbox.volumes[].path is required; size has default '10Gi'", () => {
-		const s = JSON_SCHEMA as any;
+		const s = schemaAny;
 		const volItem = s.properties.sandbox.properties.volumes.items;
 		expect(volItem.required).toContain("path");
 		expect(volItem.properties.size.default).toBe("10Gi");
 	});
 
 	test("harness.provider has default 'claude_code' and is optional", () => {
-		const s = JSON_SCHEMA as any;
+		const s = schemaAny;
 		const harness = s.properties.harness;
 		expect(harness.properties.provider.default).toBe("claude_code");
 		expect(harness.required ?? []).not.toContain("provider");
 	});
 
 	test("scheduled_jobs default is []", () => {
-		const s = JSON_SCHEMA as any;
+		const s = schemaAny;
 		expect(s.properties.scheduled_jobs.default).toEqual([]);
 	});
 
 	test("scheduled_jobs[] requires name, branch, schedule, prompt", () => {
-		const s = JSON_SCHEMA as any;
+		const s = schemaAny;
 		const item = s.properties.scheduled_jobs.items;
 		expect(item.required).toEqual(
 			expect.arrayContaining(["name", "branch", "schedule", "prompt"]),
@@ -352,25 +355,25 @@ describe("JSON_SCHEMA export", () => {
 	});
 
 	test("on_event.failed_run default is []", () => {
-		const s = JSON_SCHEMA as any;
+		const s = schemaAny;
 		const failedRun = s.properties.on_event.properties.failed_run;
 		expect(failedRun.default).toEqual([]);
 	});
 
 	test("on_event.failed_run[].workflows has minItems: 1", () => {
-		const s = JSON_SCHEMA as any;
+		const s = schemaAny;
 		const item = s.properties.on_event.properties.failed_run.items;
 		expect(item.properties.workflows.minItems).toBe(1);
 	});
 
 	test("on_event.failed_run[].branches has minItems: 1", () => {
-		const s = JSON_SCHEMA as any;
+		const s = schemaAny;
 		const item = s.properties.on_event.properties.failed_run.items;
 		expect(item.properties.branches.minItems).toBe(1);
 	});
 
 	test("on_event.failed_run[] requires workflows and branches but not prompt_additions", () => {
-		const s = JSON_SCHEMA as any;
+		const s = schemaAny;
 		const item = s.properties.on_event.properties.failed_run.items;
 		expect(item.required).toEqual(
 			expect.arrayContaining(["workflows", "branches"]),

--- a/src/config/repo-config-schema.test.ts
+++ b/src/config/repo-config-schema.test.ts
@@ -102,6 +102,7 @@ describe("resolveRepoConfigSettings — defaults applied on read", () => {
 			sandbox: { size: "medium", docker: false, volumes: [] },
 			harness: { provider: "claude_code" },
 			scheduled_jobs: [],
+			on_event: { failed_run: [] },
 		});
 	});
 	test("volume with path-only → size defaulted to '10Gi'", () => {
@@ -116,6 +117,40 @@ describe("resolveRepoConfigSettings — defaults applied on read", () => {
 		});
 		expect(r.sandbox.size).toBe("large");
 		expect(r.sandbox.docker).toBe(false);
+	});
+});
+
+describe("resolveRepoConfigSettings — on_event defaults", () => {
+	test("undefined → on_event.failed_run defaults to []", () => {
+		const r = resolveRepoConfigSettings(undefined);
+		expect(r.on_event.failed_run).toEqual([]);
+	});
+
+	test("empty object → on_event.failed_run defaults to []", () => {
+		const r = resolveRepoConfigSettings({});
+		expect(r.on_event.failed_run).toEqual([]);
+	});
+
+	test("sparse on_event with no failed_run → failed_run defaults to []", () => {
+		const r = resolveRepoConfigSettings({ on_event: {} });
+		expect(r.on_event.failed_run).toEqual([]);
+	});
+
+	test("entries passthrough", () => {
+		const r = resolveRepoConfigSettings({
+			on_event: {
+				failed_run: [
+					{
+						workflows: ["CI"],
+						branches: ["main"],
+						prompt_additions: "fix it",
+					},
+				],
+			},
+		});
+		expect(r.on_event.failed_run).toEqual([
+			{ workflows: ["CI"], branches: ["main"], prompt_additions: "fix it" },
+		]);
 	});
 });
 

--- a/src/config/repo-config-schema.test.ts
+++ b/src/config/repo-config-schema.test.ts
@@ -183,7 +183,7 @@ branches = ["main"]
 		});
 	});
 
-	test("multiple entries → preserved in order", () => {
+	test("multiple entries → preserved in order with full shape", () => {
 		const toml = `
 [[on_event.failed_run]]
 workflows = ["CI"]
@@ -194,9 +194,9 @@ workflows = ["Deploy"]
 branches = ["release"]
 `;
 		const parsed = parseRepoConfigToml(toml);
-		expect(parsed.on_event?.failed_run?.map((e) => e.workflows[0])).toEqual([
-			"CI",
-			"Deploy",
+		expect(parsed.on_event?.failed_run).toEqual([
+			{ workflows: ["CI"], branches: ["main"] },
+			{ workflows: ["Deploy"], branches: ["release"] },
 		]);
 	});
 
@@ -242,14 +242,19 @@ future_field = "ignored"
 		).toThrow(/Invalid RepoConfig/);
 	});
 
-	test("error message does not leak raw workflow/branch values", () => {
+	test("error message does not leak raw branch values on type mismatch", () => {
+		// Use branches = "not-an-array-SECRET" (type mismatch) so that the raw
+		// string itself becomes issue.input for the failing Zod issue. If the
+		// error builder ever started interpolating issue.input, the secret would
+		// surface in the message.
+		expect.assertions(2);
 		try {
 			parseRepoConfigToml(
-				`[[on_event.failed_run]]\nworkflows = ["SECRET_WORKFLOW"]`,
-				// missing branches — triggers validation error
+				`[[on_event.failed_run]]\nworkflows = ["CI"]\nbranches = "SECRET_BRANCH_VALUE"`,
 			);
 		} catch (err) {
-			expect((err as Error).message).not.toContain("SECRET_WORKFLOW");
+			expect((err as Error).message).not.toContain("SECRET_BRANCH_VALUE");
+			expect((err as Error).message).toMatch(/Invalid RepoConfig/);
 		}
 	});
 });

--- a/src/config/repo-config-schema.test.ts
+++ b/src/config/repo-config-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+	JSON_SCHEMA,
 	parseRepoConfigToml,
 	resolveRepoConfigSettings,
 } from "./repo-config-schema";
@@ -303,5 +304,81 @@ describe("volume size normalization → canonical Kubernetes binary-SI form", ()
 				`[[sandbox.volumes]]\npath = "/data"\nsize = "${input}"`,
 			),
 		).toThrow(/Invalid RepoConfig/);
+	});
+});
+
+describe("JSON_SCHEMA export", () => {
+	test("has required top-level metadata", () => {
+		expect(JSON_SCHEMA.$schema).toBe(
+			"https://json-schema.org/draft/2020-12/schema",
+		);
+		expect(JSON_SCHEMA.$id).toBeTypeOf("string");
+		expect(JSON_SCHEMA.title).toBe("code-factory repo config");
+		expect(typeof JSON_SCHEMA.description).toBe("string");
+	});
+
+	test("sandbox.size has default 'medium' and is optional", () => {
+		const s = JSON_SCHEMA as any;
+		const sandbox = s.properties.sandbox;
+		expect(sandbox.properties.size.default).toBe("medium");
+		expect(sandbox.required ?? []).not.toContain("size");
+	});
+
+	test("sandbox.volumes[].path is required; size has default '10Gi'", () => {
+		const s = JSON_SCHEMA as any;
+		const volItem = s.properties.sandbox.properties.volumes.items;
+		expect(volItem.required).toContain("path");
+		expect(volItem.properties.size.default).toBe("10Gi");
+	});
+
+	test("harness.provider has default 'claude_code' and is optional", () => {
+		const s = JSON_SCHEMA as any;
+		const harness = s.properties.harness;
+		expect(harness.properties.provider.default).toBe("claude_code");
+		expect(harness.required ?? []).not.toContain("provider");
+	});
+
+	test("scheduled_jobs default is []", () => {
+		const s = JSON_SCHEMA as any;
+		expect(s.properties.scheduled_jobs.default).toEqual([]);
+	});
+
+	test("scheduled_jobs[] requires name, branch, schedule, prompt", () => {
+		const s = JSON_SCHEMA as any;
+		const item = s.properties.scheduled_jobs.items;
+		expect(item.required).toEqual(
+			expect.arrayContaining(["name", "branch", "schedule", "prompt"]),
+		);
+	});
+
+	test("on_event.failed_run default is []", () => {
+		const s = JSON_SCHEMA as any;
+		const failedRun = s.properties.on_event.properties.failed_run;
+		expect(failedRun.default).toEqual([]);
+	});
+
+	test("on_event.failed_run[].workflows has minItems: 1", () => {
+		const s = JSON_SCHEMA as any;
+		const item = s.properties.on_event.properties.failed_run.items;
+		expect(item.properties.workflows.minItems).toBe(1);
+	});
+
+	test("on_event.failed_run[].branches has minItems: 1", () => {
+		const s = JSON_SCHEMA as any;
+		const item = s.properties.on_event.properties.failed_run.items;
+		expect(item.properties.branches.minItems).toBe(1);
+	});
+
+	test("on_event.failed_run[] requires workflows and branches but not prompt_additions", () => {
+		const s = JSON_SCHEMA as any;
+		const item = s.properties.on_event.properties.failed_run.items;
+		expect(item.required).toEqual(
+			expect.arrayContaining(["workflows", "branches"]),
+		);
+		expect(item.required ?? []).not.toContain("prompt_additions");
+	});
+
+	test("is JSON-serializable", () => {
+		expect(() => JSON.stringify(JSON_SCHEMA)).not.toThrow();
 	});
 });

--- a/src/config/repo-config-schema.ts
+++ b/src/config/repo-config-schema.ts
@@ -72,11 +72,24 @@ export const ScheduledJobSchema = z.object({
 	prompt: z.string(),
 });
 
+/** Sparse shape for a single `[[on_event.failed_run]]` entry. */
+export const StoredFailedRunEventSchema = z.object({
+	workflows: z.array(z.string()).min(1),
+	branches: z.array(z.string()).min(1),
+	prompt_additions: z.string().optional(),
+});
+
+/** Sparse shape for the `[on_event]` section. */
+export const StoredOnEventSchema = z.object({
+	failed_run: z.array(StoredFailedRunEventSchema).optional(),
+});
+
 /** Top-level sparse shape as stored by the DO. */
 export const StoredRepoConfigSettingsSchema = z.object({
 	sandbox: StoredSandboxSchema.optional(),
 	harness: StoredHarnessSchema.optional(),
 	scheduled_jobs: z.array(ScheduledJobSchema).optional(),
+	on_event: StoredOnEventSchema.optional(),
 });
 
 // ── Resolved (read-side) schemas ─────────────────────────────────────────────

--- a/src/config/repo-config-schema.ts
+++ b/src/config/repo-config-schema.ts
@@ -154,10 +154,19 @@ export const JSON_SCHEMA: Record<string, unknown> = {
 	description: "Schema for .code-factory/config.toml",
 };
 
-// Zod v4.3.6 workaround (Task 3): VolumeSizeSchema has a .transform() which
-// prevents z.toJSONSchema from emitting the `default` keyword for
-// `sandbox.volumes[].size`. Inject it narrowly after the spread.
-((JSON_SCHEMA as any).properties?.sandbox?.properties?.volumes?.items?.properties?.size ?? {}).default = "10Gi";
+// Zod v4.3.6 workaround (Task 3): VolumeSizeSchema uses `.transform()` which
+// causes `z.toJSONSchema` to drop the `default` keyword on `sandbox.volumes[].size`.
+// Inject it explicitly. If the path ever drifts (e.g. after a Zod upgrade),
+// throw loudly at module load rather than silently shipping a schema without
+// the default.
+const volumeSizeNode = (JSON_SCHEMA as any).properties?.sandbox?.properties
+	?.volumes?.items?.properties?.size;
+if (!volumeSizeNode || typeof volumeSizeNode !== "object") {
+	throw new Error(
+		"JSON_SCHEMA shape drift: sandbox.volumes[].size not found — re-check Zod z.toJSONSchema output and remove this workaround if no longer needed",
+	);
+}
+volumeSizeNode.default = "10Gi";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 

--- a/src/config/repo-config-schema.ts
+++ b/src/config/repo-config-schema.ts
@@ -140,8 +140,7 @@ export const RepoConfigSettingsSchema = z.object({
 // fields carry a `default` keyword. Consumed by editors (Taplo, VS Code) via
 // `GET /schema.json` — see `src/main.ts`.
 
-const JSON_SCHEMA_ID =
-	"https://xmtplabs.github.io/coder-action/schema/repo-config.json";
+const JSON_SCHEMA_ID = "https://task-action.xmtp.team/schema.json";
 
 export const JSON_SCHEMA: Record<string, unknown> = {
 	...(z.toJSONSchema(RepoConfigSettingsSchema, {

--- a/src/config/repo-config-schema.ts
+++ b/src/config/repo-config-schema.ts
@@ -135,6 +135,30 @@ export const RepoConfigSettingsSchema = z.object({
 	on_event: ResolvedOnEventSchema.prefault({}),
 });
 
+// ── JSON Schema (editor-consumable) ──────────────────────────────────────────
+// Generated from the resolved schema in Zod input mode so optional-with-default
+// fields carry a `default` keyword. Consumed by editors (Taplo, VS Code) via
+// `GET /schema.json` — see `src/main.ts`.
+
+const JSON_SCHEMA_ID =
+	"https://xmtplabs.github.io/coder-action/schema/repo-config.json";
+
+export const JSON_SCHEMA: Record<string, unknown> = {
+	...(z.toJSONSchema(RepoConfigSettingsSchema, {
+		io: "input",
+		target: "draft-2020-12",
+	}) as Record<string, unknown>),
+	$schema: "https://json-schema.org/draft/2020-12/schema",
+	$id: JSON_SCHEMA_ID,
+	title: "code-factory repo config",
+	description: "Schema for .code-factory/config.toml",
+};
+
+// Zod v4.3.6 workaround (Task 3): VolumeSizeSchema has a .transform() which
+// prevents z.toJSONSchema from emitting the `default` keyword for
+// `sandbox.volumes[].size`. Inject it narrowly after the spread.
+((JSON_SCHEMA as any).properties?.sandbox?.properties?.volumes?.items?.properties?.size ?? {}).default = "10Gi";
+
 // ── Types ────────────────────────────────────────────────────────────────────
 
 /** Sparse settings as stored in the DO (fields may be missing). */

--- a/src/config/repo-config-schema.ts
+++ b/src/config/repo-config-schema.ts
@@ -114,6 +114,11 @@ export const ResolvedHarnessSchema = z.object({
 	provider: HarnessProviderSchema.default("claude_code"),
 });
 
+/** Resolved on_event: failed_run defaults to []. */
+export const ResolvedOnEventSchema = z.object({
+	failed_run: z.array(StoredFailedRunEventSchema).default([]),
+});
+
 /**
  * Top-level resolved shape — always fully populated after `.parse()`.
  *
@@ -127,6 +132,7 @@ export const RepoConfigSettingsSchema = z.object({
 	sandbox: ResolvedSandboxSchema.prefault({}),
 	harness: ResolvedHarnessSchema.prefault({}),
 	scheduled_jobs: z.array(ScheduledJobSchema).default([]),
+	on_event: ResolvedOnEventSchema.prefault({}),
 });
 
 // ── Types ────────────────────────────────────────────────────────────────────

--- a/src/config/repo-config-schema.ts
+++ b/src/config/repo-config-schema.ts
@@ -159,6 +159,7 @@ export const JSON_SCHEMA: Record<string, unknown> = {
 // Inject it explicitly. If the path ever drifts (e.g. after a Zod upgrade),
 // throw loudly at module load rather than silently shipping a schema without
 // the default.
+// biome-ignore lint/suspicious/noExplicitAny: traverses Zod's generated JSON Schema, which has a recursive any-ish shape
 const volumeSizeNode = (JSON_SCHEMA as any).properties?.sandbox?.properties
 	?.volumes?.items?.properties?.size;
 if (!volumeSizeNode || typeof volumeSizeNode !== "object") {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import worker, { __setAppBotLoginForTests } from "./main";
+import { JSON_SCHEMA } from "./config/repo-config-schema";
 import issuesAssigned from "./testing/fixtures/issues-assigned.json";
 import workflowRunSuccess from "./testing/fixtures/workflow-run-success.json";
 import { computeSignature } from "./testing/workflow-test-helpers";
@@ -35,13 +36,7 @@ describe("GET /schema.json", () => {
 		});
 		const res = await worker.fetch(req, {} as never, {} as ExecutionContext);
 		const body = await res.json();
-		expect((body as any).$schema).toBe(
-			"https://json-schema.org/draft/2020-12/schema",
-		);
-		expect((body as any).title).toBe("code-factory repo config");
-		expect(
-			(body as any).properties.sandbox.properties.size.default,
-		).toBe("medium");
+		expect(body).toEqual(JSON_SCHEMA);
 	});
 
 	test("non-GET method falls through to 404", async () => {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -16,6 +16,43 @@ describe("Worker default export", () => {
 	});
 });
 
+describe("GET /schema.json", () => {
+	test("returns 200 with application/schema+json", async () => {
+		const req = new Request("https://example.com/schema.json", {
+			method: "GET",
+		});
+		const res = await worker.fetch(req, {} as never, {} as ExecutionContext);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toBe(
+			"application/schema+json; charset=utf-8",
+		);
+		expect(res.headers.get("cache-control")).toBe("public, max-age=300");
+	});
+
+	test("body is the exported JSON_SCHEMA", async () => {
+		const req = new Request("https://example.com/schema.json", {
+			method: "GET",
+		});
+		const res = await worker.fetch(req, {} as never, {} as ExecutionContext);
+		const body = await res.json();
+		expect((body as any).$schema).toBe(
+			"https://json-schema.org/draft/2020-12/schema",
+		);
+		expect((body as any).title).toBe("code-factory repo config");
+		expect(
+			(body as any).properties.sandbox.properties.size.default,
+		).toBe("medium");
+	});
+
+	test("non-GET method falls through to 404", async () => {
+		const req = new Request("https://example.com/schema.json", {
+			method: "POST",
+		});
+		const res = await worker.fetch(req, {} as never, {} as ExecutionContext);
+		expect(res.status).toBe(404);
+	});
+});
+
 // ── Worker tracing bindings ───────────────────────────────────────────────────
 //
 // The Worker's `handleGithubWebhook` builds `reqLogger` after

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { loadConfig } from "./config/app-config";
+import { JSON_SCHEMA } from "./config/repo-config-schema";
 import {
 	__setAppBotLoginForTests,
 	resolveAppBotLogin,
@@ -32,6 +33,16 @@ export default {
 
 		if (request.method === "POST" && url.pathname === "/webhooks/github") {
 			return handleGithubWebhook(request, env);
+		}
+
+		if (request.method === "GET" && url.pathname === "/schema.json") {
+			return new Response(JSON.stringify(JSON_SCHEMA), {
+				status: 200,
+				headers: {
+					"content-type": "application/schema+json; charset=utf-8",
+					"cache-control": "public, max-age=300",
+				},
+			});
 		}
 
 		return new Response("Not Found", { status: 404 });

--- a/src/workflows/steps/create-task.test.ts
+++ b/src/workflows/steps/create-task.test.ts
@@ -338,6 +338,7 @@ describe("runCreateTask", () => {
 				},
 				harness: { provider: "codex" },
 				scheduled_jobs: [],
+				on_event: { failed_run: [] },
 			},
 		};
 		await runCreateTask({


### PR DESCRIPTION
## Summary

Extends `.code-factory/config.toml` with a new `[[on_event.failed_run]]` section, serves a machine-readable JSON Schema at `GET /schema.json` for editor integration, and publishes a human-readable reference at `docs/repo-config.md`. No consumer of `on_event.failed_run` is added in this PR — this is schema plumbing plus docs only.

## What ships

**Schema extensions** (`src/config/repo-config-schema.ts`)
- New `StoredFailedRunEventSchema` / `StoredOnEventSchema` on the sparse (write-side) shape. `workflows` and `branches` are required non-empty arrays; `prompt_additions` is optional.
- New `ResolvedOnEventSchema` on the resolved (read-side) shape, wired with `.prefault({})` + inner `.default([])` so consumers always see `on_event.failed_run: []` when the section is absent.
- Secret-leak invariant preserved: error messages are still built from `issue.path + issue.message` only, never `issue.input`.

**`GET /schema.json` endpoint** (`src/main.ts`)
- Generated at module load via `z.toJSONSchema(RepoConfigSettingsSchema, { io: "input", target: "draft-2020-12" })` so optional-with-default fields carry a `default` keyword.
- Served with `content-type: application/schema+json; charset=utf-8` and `cache-control: public, max-age=300`.
- `$id` set to `https://task-action.xmtp.team/schema.json`.
- Narrow post-process fixes a Zod v4.3.6 quirk: `VolumeSizeSchema` uses `.transform()` which causes `z.toJSONSchema` to drop the `default` keyword on `sandbox.volumes[].size`. The workaround re-injects `default: \"10Gi\"` and throws loudly at module load if the shape ever drifts.

**Reference docs** (`docs/repo-config.md`)
- Every config section and field documented with type, default, required/optional status.
- Editor integration snippets for Taplo `#:schema` directive and `.taplo.toml`.
- Linked from `README.md` (new Per-repo configuration subsection) and `AGENTS.md` (Reference list).
- `.code-factory/config.toml` now carries a `#:schema` directive so editors fetch the schema automatically.

## Non-goals (deliberately deferred)

- No consumer of `on_event.failed_run` — no event router, no failed-run handler workflow. The block validates today; dispatch is a follow-up.
- No Taplo `x-taplo` extension keywords, no build-time static schema asset, no version migration.

## Test plan

- [x] `npm run check` — 401 tests across 32 files, typecheck/lint/format clean
- [x] New `parseRepoConfigToml — on_event.failed_run` coverage: full entry, optional `prompt_additions`, multiple entries (full-shape assertion), unknown-key stripping, four required/non-empty error paths, and a type-mismatch secret-leak regression guard using `expect.assertions(2)`
- [x] New `resolveRepoConfigSettings — on_event defaults` coverage: `undefined`, `{}`, sparse `on_event: {}`, and entry passthrough
- [x] New `JSON_SCHEMA export` coverage (11 tests): metadata, all `default` keywords, `minItems: 1`, required-field sets, `prompt_additions` NOT required, serializability
- [x] New `GET /schema.json` coverage (3 tests): 200 + headers, body deep-equals `JSON_SCHEMA`, non-GET falls through to 404
- [x] Existing regression anchors intact: unknown-top-level-key stripping, volume size normalization, `POST /webhooks/github` dispatch, the `main.test.ts` unknown-route 404 test

## Spec / task list

- Design: `docs/plans/2026-04-22-repo-config-schema-extensions-design.md`
- Decomposition: `docs/plans/2026-04-22-repo-config-schema-extensions-tasks.md`

All 19 EARS requirements validated by final spec review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `on_event.failed_run` schema to repo config and serve it at `/schema.json`
> - Added `[[on_event.failed_run]]` support to [repo-config-schema.ts](https://github.com/xmtplabs/coder-action/pull/123/files#diff-d38815f7c2f5fb231483a3643dfc4ef2f141b73ddb022f1222b22eb81c2f78fc): each entry requires non-empty `workflows` and `branches` arrays, with an optional `prompt_additions` field; resolved configs default `on_event.failed_run` to `[]`.
> - Added a `JSON_Schema` export generated from the resolved schema in input mode, with `$schema`, `$id`, `title`, and `description` set; a workaround injects the `sandbox.volumes[].size` default lost during the zod transform, and throws on module load if the path is missing.
> - Added a `GET /schema.json` route in [main.ts](https://github.com/xmtplabs/coder-action/pull/123/files#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3d) that returns the schema with `content-type: application/schema+json` and a 5-minute public cache.
> - Added documentation in [docs/repo-config.md](https://github.com/xmtplabs/coder-action/pull/123/files#diff-972a0c9e4568275e3d6e81001482eabecd3d007d0d9cfcd07d36ae80eae0c143) covering the full `.code-factory/config.toml` format and editor integration via the served schema.
> - Risk: module load throws if the expected `sandbox.volumes[].size` schema path is absent, which would prevent worker startup if the schema structure changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ba222e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->