### PR TITLE
refactor(messages): delegate comment handling to /receiving-feedback skill

### DIFF
--- a/src/actions/messages.test.ts
+++ b/src/actions/messages.test.ts
@@ -38,15 +38,18 @@ describe("formatPRCommentMessage", () => {
 		expect(instrIdx).toBeLessThan(commentIdx);
 	});
 
-	test("instructs agent to react with 👍 for automated non-actionable comments", () => {
+	test("delegates handling to the /receiving-feedback skill", () => {
 		const msg = formatPRCommentMessage({
 			commentUrl: "https://github.com/org/repo/pull/1#comment-1",
 			commenter: "bot",
 			timestamp: "2026-03-17T12:00:00Z",
 			body: "Approvability check passed",
 		});
-		expect(msg).toContain("👍");
-		expect(msg).toContain("automated");
+		expect(msg).toContain(
+			"Use the /receiving-feedback skill to handle the following comment.",
+		);
+		expect(msg).not.toContain("👍");
+		expect(msg).not.toContain("automated");
 	});
 
 	test("includes file path and line number for review comments", () => {
@@ -114,15 +117,18 @@ describe("formatIssueCommentMessage", () => {
 		expect(instrIdx).toBeLessThan(commentIdx);
 	});
 
-	test("instructs agent to react with 👍 for automated non-actionable comments", () => {
+	test("delegates handling to the /receiving-feedback skill", () => {
 		const msg = formatIssueCommentMessage({
 			commentUrl: "https://github.com/org/repo/issues/42#comment-1",
 			commenter: "github-actions",
 			timestamp: "2026-03-17T12:00:00Z",
 			body: "Task created: https://coder.example.com/tasks/123",
 		});
-		expect(msg).toContain("👍");
-		expect(msg).toContain("automated");
+		expect(msg).toContain(
+			"Use the /receiving-feedback skill to handle the following comment.",
+		);
+		expect(msg).not.toContain("👍");
+		expect(msg).not.toContain("automated");
 	});
 });
 

--- a/src/actions/messages.ts
+++ b/src/actions/messages.ts
@@ -27,15 +27,7 @@ Commenter: ${params.commenter}
 Timestamp: ${params.timestamp}${locationLine}
 
 [INSTRUCTIONS]
-First, determine whether this comment requires action.
-
-If the comment is automated and does not require code changes or a reply — for example: bot status updates, approvability checks, CI notifications, merge conflict warnings, or other non-human automated comments — react to the comment with a 👍 emoji and take no further action.
-
-If the comment contains valid suggestions or feedback from a human reviewer, implement them, ensure the branch is still in a healthy state (all lint and tests continue to pass), then commit and push. Reply to the comment with a succinct and clear explanation of the changes you made.
-
-If you have questions or need clarification, ask them directly in the comment thread and wait for further feedback.
-
-If no changes are needed or the comment is invalid feedback, reply to the comment with a succinct and clear explanation why no action was taken.
+Use the /receiving-feedback skill to handle the following comment.
 [END INSTRUCTIONS]
 
 [COMMENT]
@@ -51,13 +43,7 @@ Commenter: ${params.commenter}
 Timestamp: ${params.timestamp}
 
 [INSTRUCTIONS]
-First, determine whether this comment requires action.
-
-If the comment is automated and does not contain actionable information — for example: bot status updates, CI notifications, task tracking comments, or other non-human automated comments — react to the comment with a 👍 emoji and take no further action.
-
-If the comment contains new requirements, clarifications, or feedback that affects your current work, adjust your approach accordingly.
-
-If the comment asks a question, reply directly on the issue.
+Use the /receiving-feedback skill to handle the following comment.
 [END INSTRUCTIONS]
 
 [COMMENT]


### PR DESCRIPTION
Resolves https://github.com/xmtplabs/coder-action/issues/124

## Summary

Replaces the verbose, multi-paragraph `[INSTRUCTIONS]` block inside `formatPRCommentMessage` and `formatIssueCommentMessage` (`src/actions/messages.ts`) with a single line:

> Use the /receiving-feedback skill to handle the following comment.

The agent already owns that decision logic via its `receiving-feedback` skill, so keeping a duplicate copy in the message template forced both copies to be kept in sync. This delegates to the skill and keeps the message format clean.

## Changes

- `src/actions/messages.ts` — simplified `[INSTRUCTIONS]` block in both `formatPRCommentMessage` and `formatIssueCommentMessage`. `formatFailedCheckMessage` is untouched (out of scope).
- `src/actions/messages.test.ts` — the two "reacts with 👍 for automated" tests now assert the new single-line directive is present and that the old wording (`👍`, `automated`) is gone. Header / delimiter / `File:` / body-content tests unchanged.
- Public signatures and the surrounding message frame (headers, `[INSTRUCTIONS]` / `[END INSTRUCTIONS]` / `[COMMENT]` / `[END COMMENT]` delimiters, instructions-before-body ordering) are preserved, so call-sites in `src/workflows/steps/comment.ts` and `comment.test.ts` require no changes.

## Test plan

- [x] `npm run check` (typecheck + lint + format + 401 vitest tests) passes
- [ ] Reviewer confirms the new directive wording is what you want

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace detailed comment instructions with `/receiving-feedback` skill directive in PR and issue messages
> Updates `formatPRCommentMessage` and `formatIssueCommentMessage` in [messages.ts](https://github.com/xmtplabs/coder-action/pull/125/files#diff-7f1ed7dadb2a44d94ee857f11596ab183b3ff40aca0a03e29ba96e87becbeaea) to replace multi-step guidance (including thumbs-up reactions and automated comment handling) with a single directive to use the `/receiving-feedback` skill. Tests in [messages.test.ts](https://github.com/xmtplabs/coder-action/pull/125/files#diff-071314b96630e7c6ad9f06146d1683badde0ae9a38e06de780927962dd77f9f9) are updated to match the new output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2f55a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->